### PR TITLE
feat: add health check endpoints and Docker healthcheck configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,6 @@ COPY package.json bun.lockb bun.lock ./
 
 RUN mkdir -p /app/data
 EXPOSE 4000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD ["bun", "-e", "const port = process.env.PORT || '4000'; const url = 'http://127.0.0.1:' + port + '/health'; const res = await fetch(url); if (!res.ok) throw new Error('Health check failed with status ' + res.status); const payload = await res.json(); if (!payload?.ok) throw new Error('Health payload not ok');"]
 CMD ["bun", "server/index.ts"]

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Notes:
 - Data is persisted via `/app/data` (default `COOKBOOK_DB_PATH=/app/data/cookbook.db`).
 - Override listen address/port with `HOST` / `PORT` env vars if needed.
 - Optional auth can also be set via env (`AUTH_ENABLED`, `AUTH_USERNAME`, `AUTH_PASSWORD`).
+- Image includes a Docker `HEALTHCHECK` that probes `GET /health`, so `docker ps` reports `healthy`/`unhealthy`.
 
 ## Backend Overview
 - `server/index.ts` boots the Bun SQLite DB (WAL + FK) and defines routes such as:

--- a/server/index.ts
+++ b/server/index.ts
@@ -576,6 +576,7 @@ export const app = new Elysia({
 		const session = getAuthSession(request);
 		if (!session.authenticated) return unauthorized(set);
 	})
+	.get('/health', () => ({ ok: true }))
 	.get('/api/health', () => ({ ok: true }))
 	.get('/api/auth/status', ({ request }) => {
 		if (!authEnabled) return { enabled: false, authenticated: true };

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -176,6 +176,21 @@ describe('auth', () => {
 		}
 	});
 
+	test('keeps health endpoints publicly accessible when auth is enabled', async () => {
+		const server = await loadServer();
+		try {
+			const rootHealth = await callApi(server.app, '/health');
+			expect(rootHealth.status).toBe(200);
+			await expect(rootHealth.json()).resolves.toEqual({ ok: true });
+
+			const apiHealth = await callApi(server.app, '/api/health');
+			expect(apiHealth.status).toBe(200);
+			await expect(apiHealth.json()).resolves.toEqual({ ok: true });
+		} finally {
+			closeServer(server);
+		}
+	});
+
 	test('sets remember-permanent login max-age to ten years', async () => {
 		const server = await loadServer();
 		try {


### PR DESCRIPTION
- Implemented `/health` and `/api/health` endpoints for health status checks.
- Added Docker `HEALTHCHECK` to probe the health endpoints.
- Updated README to document the new healthcheck feature.
- Added tests to ensure health endpoints are accessible when auth is enabled.