### PR TITLE
Simplify Compose healthcheck probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,19 +138,15 @@ Notes:
 - Override listen address/port with `HOST` / `PORT` env vars if needed.
 - Optional auth can also be set via env (`AUTH_ENABLED`, `AUTH_USERNAME`, `AUTH_PASSWORD`).
 - Image includes a Docker `HEALTHCHECK` that probes `GET /health`, so `docker ps` reports `healthy`/`unhealthy`.
-- The image-level `HEALTHCHECK` timings are baked into the image. Runtime env vars such as `HEALTHCHECK_INTERVAL` do not affect `docker run` by themselves.
+- The image-level `HEALTHCHECK` timings are baked into the image.
 
-If you want healthcheck timings to come from `.env`, use the provided `compose.yml`:
+If you want to tweak the container policy in Compose, use the provided `compose.yml`:
 
 ```bash
 docker compose up --build -d
 ```
 
-`compose.yml` wires these env vars into the service healthcheck:
-- `HEALTHCHECK_INTERVAL`
-- `HEALTHCHECK_TIMEOUT`
-- `HEALTHCHECK_START_PERIOD`
-- `HEALTHCHECK_RETRIES`
+`compose.yml` keeps the same `/health` probe in a plain `wget`-based healthcheck block that you can edit directly.
 
 With Compose, the container still probes `GET /health`, and the app still uses:
 - `PORT`

--- a/compose.yml
+++ b/compose.yml
@@ -12,64 +12,17 @@ services:
       AUTH_ENABLED: ${AUTH_ENABLED:-false}
       AUTH_USERNAME: ${AUTH_USERNAME:-}
       AUTH_PASSWORD: ${AUTH_PASSWORD:-}
-      HEALTHCHECK_TIMEOUT: ${HEALTHCHECK_TIMEOUT:-3s}
     volumes:
       - cookbook_data:/app/data
     restart: unless-stopped
     healthcheck:
       test:
         - CMD-SHELL
-        - >-
-          port="$${PORT:-4000}";
-          timeout="$${HEALTHCHECK_TIMEOUT:-3s}";
-          case "$$port" in ''|*[!0-9]*) port=4000 ;; esac;
-          [ "$$port" -gt 0 ] 2>/dev/null || port=4000;
-          http_timeout_ms=0;
-          valid_timeout=1;
-          remaining="$$timeout";
-          case "$$remaining" in *[!0-9smh]*) valid_timeout=0 ;; esac;
-          while [ "$$valid_timeout" -eq 1 ] && [ -n "$$remaining" ]; do
-            number="$${remaining%%[!0-9]*}";
-            [ -n "$$number" ] || { valid_timeout=0; break; };
-            rest="$${remaining#$$number}";
-            if [ -z "$$rest" ]; then
-              if [ "$$remaining" = "$$timeout" ]; then
-                http_timeout_ms=$$((http_timeout_ms + number * 1000));
-              else
-                valid_timeout=0;
-              fi;
-              break;
-            fi;
-            case "$$rest" in
-              ms*)
-                remaining="$${rest#ms}";
-                http_timeout_ms=$$((http_timeout_ms + number))
-                ;;
-              s*)
-                remaining="$${rest#?}";
-                http_timeout_ms=$$((http_timeout_ms + number * 1000))
-                ;;
-              m*)
-                remaining="$${rest#?}";
-                http_timeout_ms=$$((http_timeout_ms + number * 60000))
-                ;;
-              h*)
-                remaining="$${rest#?}";
-                http_timeout_ms=$$((http_timeout_ms + number * 3600000))
-                ;;
-              *)
-                valid_timeout=0
-                ;;
-            esac;
-          done;
-          [ "$$valid_timeout" -eq 1 ] || http_timeout_ms=3000;
-          [ "$$http_timeout_ms" -gt 0 ] 2>/dev/null || http_timeout_ms=3000;
-          http_timeout=$$(((http_timeout_ms + 999) / 1000));
-          wget -q -T "$$http_timeout" -O /dev/null "http://127.0.0.1:$${port}/health" || exit 1
-      interval: ${HEALTHCHECK_INTERVAL:-2m}
-      timeout: ${HEALTHCHECK_TIMEOUT:-3s}
-      start_period: ${HEALTHCHECK_START_PERIOD:-20s}
-      retries: ${HEALTHCHECK_RETRIES:-3}
+        - wget -q -O /dev/null "http://127.0.0.1:$${PORT:-4000}/health" || exit 1
+      interval: 2m
+      timeout: 3s
+      start_period: 20s
+      retries: 3
 
 volumes:
   cookbook_data:


### PR DESCRIPTION
## Summary
- Replace the Compose healthcheck shell block with a plain `wget` probe against `/health`.
- Remove the extra `HEALTHCHECK_*` env wiring from `compose.yml`.
- Update the README to match the simpler Compose policy.

## Testing
- Not run (not requested)