### PR TITLE
fix: deny cross-origin cookie API requests

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -385,10 +385,18 @@ const protectedPrefixes = ['/api/cookbooks', '/api/recipes', '/api/tags', '/api/
 const isProtectedApiPath = (pathname: string) =>
 	protectedPrefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 
+const isAuthApiPath = (pathname: string) => pathname === '/api/auth' || pathname.startsWith('/api/auth/');
+
 const isCorsPreflightRequest = (request: Request) =>
 	request.method === 'OPTIONS' &&
 	Boolean(request.headers.get('origin')) &&
 	Boolean(request.headers.get('access-control-request-method'));
+
+const isSameOriginRequest = (request: Request) => {
+	const origin = request.headers.get('origin');
+	if (!origin) return true;
+	return origin === new URL(request.url).origin;
+};
 
 const parseCookies = (value: string | null) => {
 	const cookies: Record<string, string> = {};
@@ -612,8 +620,11 @@ export const app = new Elysia({
 	.onBeforeHandle(({ request, set }) => {
 		if (!authEnabled) return;
 		const pathname = new URL(request.url).pathname;
-		if (!isProtectedApiPath(pathname)) return;
+		const isProtectedPath = isProtectedApiPath(pathname);
+		if (!isProtectedPath && !isAuthApiPath(pathname)) return;
 		if (isCorsPreflightRequest(request)) return;
+		if (!isSameOriginRequest(request)) return badRequest(set, 'cross-origin API request denied');
+		if (!isProtectedPath) return;
 		const session = getAuthSession(request);
 		if (!session.authenticated) return unauthorized(set);
 	})

--- a/server/index.ts
+++ b/server/index.ts
@@ -113,7 +113,6 @@ const isTruthyEnv = (value: string | undefined) => {
 	return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
 };
 const authEnabled = isTruthyEnv(process.env.AUTH_ENABLED);
-const trustProxyHeaders = isTruthyEnv(process.env.TRUST_PROXY_HEADERS);
 const authUsername = process.env.AUTH_USERNAME?.trim() ?? '';
 const authPassword = process.env.AUTH_PASSWORD ?? '';
 if (authEnabled && (!authUsername || !authPassword)) {
@@ -423,8 +422,7 @@ const normalizeProtocol = (value: string | null) => {
 	return null;
 };
 
-const getForwardedProtocol = (request: Request, options?: { requireTrustedProxy?: boolean }) => {
-	if (options?.requireTrustedProxy && !trustProxyHeaders) return null;
+const getForwardedProtocol = (request: Request) => {
 	return normalizeProtocol(firstHeaderValue(request.headers.get('x-forwarded-proto'))) ?? normalizeProtocol(forwardedParameter(request, 'proto'));
 };
 
@@ -441,7 +439,7 @@ const normalizeHost = (value: string | null, protocol = 'http:') => {
 
 const getRequestOrigins = (request: Request) => {
 	const url = new URL(request.url);
-	const protocol = getForwardedProtocol(request, { requireTrustedProxy: true }) ?? url.protocol;
+	const protocol = getForwardedProtocol(request) ?? url.protocol;
 	const directHost = normalizeHost(request.headers.get('host'), protocol) ?? url.host;
 	return new Set([`${protocol}//${directHost}`]);
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -113,6 +113,7 @@ const isTruthyEnv = (value: string | undefined) => {
 	return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
 };
 const authEnabled = isTruthyEnv(process.env.AUTH_ENABLED);
+const trustProxyHeaders = isTruthyEnv(process.env.TRUST_PROXY_HEADERS);
 const authUsername = process.env.AUTH_USERNAME?.trim() ?? '';
 const authPassword = process.env.AUTH_PASSWORD ?? '';
 if (authEnabled && (!authUsername || !authPassword)) {
@@ -423,6 +424,7 @@ const normalizeProtocol = (value: string | null) => {
 };
 
 const getForwardedProtocol = (request: Request) => {
+	if (!trustProxyHeaders) return null;
 	return normalizeProtocol(firstHeaderValue(request.headers.get('x-forwarded-proto'))) ?? normalizeProtocol(forwardedParameter(request, 'proto'));
 };
 
@@ -438,6 +440,7 @@ const normalizeHost = (value: string | null) => {
 };
 
 const getForwardedHost = (request: Request) => {
+	if (!trustProxyHeaders) return null;
 	return normalizeHost(firstHeaderValue(request.headers.get('x-forwarded-host'))) ?? normalizeHost(forwardedParameter(request, 'host'));
 };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -423,8 +423,8 @@ const normalizeProtocol = (value: string | null) => {
 	return null;
 };
 
-const getForwardedProtocol = (request: Request) => {
-	if (!trustProxyHeaders) return null;
+const getForwardedProtocol = (request: Request, options?: { requireTrustedProxy?: boolean }) => {
+	if (options?.requireTrustedProxy && !trustProxyHeaders) return null;
 	return normalizeProtocol(firstHeaderValue(request.headers.get('x-forwarded-proto'))) ?? normalizeProtocol(forwardedParameter(request, 'proto'));
 };
 
@@ -446,7 +446,7 @@ const getForwardedHost = (request: Request, protocol: string) => {
 
 const getRequestOrigins = (request: Request) => {
 	const url = new URL(request.url);
-	const protocol = getForwardedProtocol(request) ?? url.protocol;
+	const protocol = getForwardedProtocol(request, { requireTrustedProxy: true }) ?? url.protocol;
 	const directHost = normalizeHost(request.headers.get('host'), protocol) ?? url.host;
 	const origins = new Set([`${protocol}//${directHost}`]);
 	const forwardedHost = getForwardedHost(request, protocol);

--- a/server/index.ts
+++ b/server/index.ts
@@ -439,19 +439,11 @@ const normalizeHost = (value: string | null, protocol = 'http:') => {
 	}
 };
 
-const getForwardedHost = (request: Request, protocol: string) => {
-	if (!trustProxyHeaders) return null;
-	return normalizeHost(firstHeaderValue(request.headers.get('x-forwarded-host')), protocol) ?? normalizeHost(forwardedParameter(request, 'host'), protocol);
-};
-
 const getRequestOrigins = (request: Request) => {
 	const url = new URL(request.url);
 	const protocol = getForwardedProtocol(request, { requireTrustedProxy: true }) ?? url.protocol;
 	const directHost = normalizeHost(request.headers.get('host'), protocol) ?? url.host;
-	const origins = new Set([`${protocol}//${directHost}`]);
-	const forwardedHost = getForwardedHost(request, protocol);
-	if (forwardedHost) origins.add(`${protocol}//${forwardedHost}`);
-	return origins;
+	return new Set([`${protocol}//${directHost}`]);
 };
 
 const isSameOriginRequest = (request: Request) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -394,24 +394,68 @@ const isCorsPreflightRequest = (request: Request) =>
 
 const firstHeaderValue = (value: string | null) => value?.split(',')[0]?.trim() || null;
 
-const getForwardedProtocol = (request: Request) => {
-	const proto = firstHeaderValue(request.headers.get('x-forwarded-proto'))?.toLowerCase();
+const unquoteHeaderValue = (value: string) => {
+	const trimmed = value.trim();
+	if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+		return trimmed.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+	}
+	return trimmed;
+};
+
+const forwardedParameter = (request: Request, name: string) => {
+	const forwarded = firstHeaderValue(request.headers.get('forwarded'));
+	if (!forwarded) return null;
+	for (const part of forwarded.split(';')) {
+		const separator = part.indexOf('=');
+		if (separator <= 0) continue;
+		const key = part.slice(0, separator).trim().toLowerCase();
+		if (key !== name) continue;
+		const value = unquoteHeaderValue(part.slice(separator + 1));
+		return value || null;
+	}
+	return null;
+};
+
+const normalizeProtocol = (value: string | null) => {
+	const proto = value?.trim().toLowerCase();
 	if (proto === 'http' || proto === 'https') return `${proto}:`;
 	return null;
 };
 
-const getRequestOrigin = (request: Request) => {
+const getForwardedProtocol = (request: Request) => {
+	return normalizeProtocol(firstHeaderValue(request.headers.get('x-forwarded-proto'))) ?? normalizeProtocol(forwardedParameter(request, 'proto'));
+};
+
+const normalizeHost = (value: string | null) => {
+	if (!value) return null;
+	const host = unquoteHeaderValue(value);
+	if (!host || /[\s/\\]/.test(host)) return null;
+	try {
+		return new URL(`http://${host}`).host;
+	} catch {
+		return null;
+	}
+};
+
+const getForwardedHost = (request: Request) => {
+	return normalizeHost(firstHeaderValue(request.headers.get('x-forwarded-host'))) ?? normalizeHost(forwardedParameter(request, 'host'));
+};
+
+const getRequestOrigins = (request: Request) => {
 	const url = new URL(request.url);
 	const protocol = getForwardedProtocol(request) ?? url.protocol;
-	const host = request.headers.get('host')?.trim() || url.host;
-	return `${protocol}//${host}`;
+	const directHost = normalizeHost(request.headers.get('host')) ?? url.host;
+	const origins = new Set([`${protocol}//${directHost}`]);
+	const forwardedHost = getForwardedHost(request);
+	if (forwardedHost) origins.add(`${protocol}//${forwardedHost}`);
+	return origins;
 };
 
 const isSameOriginRequest = (request: Request) => {
 	const origin = request.headers.get('origin');
 	if (!origin) return true;
 	try {
-		return new URL(origin).origin === getRequestOrigin(request);
+		return getRequestOrigins(request).has(new URL(origin).origin);
 	} catch {
 		return false;
 	}

--- a/server/index.ts
+++ b/server/index.ts
@@ -392,10 +392,29 @@ const isCorsPreflightRequest = (request: Request) =>
 	Boolean(request.headers.get('origin')) &&
 	Boolean(request.headers.get('access-control-request-method'));
 
+const firstHeaderValue = (value: string | null) => value?.split(',')[0]?.trim() || null;
+
+const getForwardedProtocol = (request: Request) => {
+	const proto = firstHeaderValue(request.headers.get('x-forwarded-proto'))?.toLowerCase();
+	if (proto === 'http' || proto === 'https') return `${proto}:`;
+	return null;
+};
+
+const getRequestOrigin = (request: Request) => {
+	const url = new URL(request.url);
+	const protocol = getForwardedProtocol(request) ?? url.protocol;
+	const host = request.headers.get('host')?.trim() || url.host;
+	return `${protocol}//${host}`;
+};
+
 const isSameOriginRequest = (request: Request) => {
 	const origin = request.headers.get('origin');
 	if (!origin) return true;
-	return origin === new URL(request.url).origin;
+	try {
+		return new URL(origin).origin === getRequestOrigin(request);
+	} catch {
+		return false;
+	}
 };
 
 const parseCookies = (value: string | null) => {
@@ -470,10 +489,7 @@ const getAuthSession = (request: Request): AuthSession => {
 const isSecureRequest = (request: Request) => {
 	const url = new URL(request.url);
 	if (url.protocol === 'https:') return true;
-	const forwardedProto = request.headers.get('x-forwarded-proto');
-	if (!forwardedProto) return false;
-	const proto = forwardedProto.split(',')[0]?.trim().toLowerCase();
-	return proto === 'https';
+	return getForwardedProtocol(request) === 'https:';
 };
 
 const buildSessionCookie = (value: string, maxAgeSeconds: number, request: Request) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -428,28 +428,28 @@ const getForwardedProtocol = (request: Request) => {
 	return normalizeProtocol(firstHeaderValue(request.headers.get('x-forwarded-proto'))) ?? normalizeProtocol(forwardedParameter(request, 'proto'));
 };
 
-const normalizeHost = (value: string | null) => {
+const normalizeHost = (value: string | null, protocol = 'http:') => {
 	if (!value) return null;
 	const host = unquoteHeaderValue(value);
 	if (!host || /[\s/\\]/.test(host)) return null;
 	try {
-		return new URL(`http://${host}`).host;
+		return new URL(`${protocol}//${host}`).host;
 	} catch {
 		return null;
 	}
 };
 
-const getForwardedHost = (request: Request) => {
+const getForwardedHost = (request: Request, protocol: string) => {
 	if (!trustProxyHeaders) return null;
-	return normalizeHost(firstHeaderValue(request.headers.get('x-forwarded-host'))) ?? normalizeHost(forwardedParameter(request, 'host'));
+	return normalizeHost(firstHeaderValue(request.headers.get('x-forwarded-host')), protocol) ?? normalizeHost(forwardedParameter(request, 'host'), protocol);
 };
 
 const getRequestOrigins = (request: Request) => {
 	const url = new URL(request.url);
 	const protocol = getForwardedProtocol(request) ?? url.protocol;
-	const directHost = normalizeHost(request.headers.get('host')) ?? url.host;
+	const directHost = normalizeHost(request.headers.get('host'), protocol) ?? url.host;
 	const origins = new Set([`${protocol}//${directHost}`]);
-	const forwardedHost = getForwardedHost(request);
+	const forwardedHost = getForwardedHost(request, protocol);
 	if (forwardedHost) origins.add(`${protocol}//${forwardedHost}`);
 	return origins;
 };

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -182,7 +182,9 @@ describe('auth', () => {
 			const login = await callApi(server.app, '/api/auth/login', {
 				method: 'POST',
 				headers: {
-					Origin: 'https://localhost',
+					Host: 'upstream.internal:4000',
+					Origin: 'https://cookbook.example.test',
+					'X-Forwarded-Host': 'cookbook.example.test',
 					'X-Forwarded-Proto': 'https'
 				},
 				body: JSON.stringify({ username: 'chef', password: 'secret' })
@@ -195,12 +197,24 @@ describe('auth', () => {
 				method: 'POST',
 				headers: {
 					Cookie: session,
-					Origin: 'https://localhost',
+					Host: 'upstream.internal:4000',
+					Origin: 'https://cookbook.example.test',
+					'X-Forwarded-Host': 'cookbook.example.test',
 					'X-Forwarded-Proto': 'https'
 				},
 				body: JSON.stringify({ name: 'Proxy Allowed' })
 			});
 			expect(sameOriginCreate.status).toBe(200);
+
+			const sameOriginStatus = await callApi(server.app, '/api/auth/status', {
+				headers: {
+					Cookie: session,
+					Host: 'upstream.internal:4000',
+					Origin: 'https://cookbook.example.test',
+					Forwarded: 'proto=https;host=cookbook.example.test'
+				}
+			});
+			expect(sameOriginStatus.status).toBe(200);
 		} finally {
 			closeServer(server);
 		}

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -199,7 +199,7 @@ describe('auth', () => {
 					Cookie: session,
 					Host: 'upstream.internal:4000',
 					Origin: 'https://cookbook.example.test',
-					'X-Forwarded-Host': 'cookbook.example.test',
+					'X-Forwarded-Host': 'cookbook.example.test:443',
 					'X-Forwarded-Proto': 'https'
 				},
 				body: JSON.stringify({ name: 'Proxy Allowed' })
@@ -211,7 +211,7 @@ describe('auth', () => {
 					Cookie: session,
 					Host: 'upstream.internal:4000',
 					Origin: 'https://cookbook.example.test',
-					Forwarded: 'proto=https;host=cookbook.example.test'
+					Forwarded: 'proto=https;host=cookbook.example.test:443'
 				}
 			});
 			expect(sameOriginStatus.status).toBe(200);

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -182,9 +182,8 @@ describe('auth', () => {
 			const login = await callApi(server.app, '/api/auth/login', {
 				method: 'POST',
 				headers: {
-					Host: 'upstream.internal:4000',
+					Host: 'cookbook.example.test:443',
 					Origin: 'https://cookbook.example.test',
-					'X-Forwarded-Host': 'cookbook.example.test',
 					'X-Forwarded-Proto': 'https'
 				},
 				body: JSON.stringify({ username: 'chef', password: 'secret' })
@@ -197,9 +196,8 @@ describe('auth', () => {
 				method: 'POST',
 				headers: {
 					Cookie: session,
-					Host: 'upstream.internal:4000',
+					Host: 'cookbook.example.test:443',
 					Origin: 'https://cookbook.example.test',
-					'X-Forwarded-Host': 'cookbook.example.test:443',
 					'X-Forwarded-Proto': 'https'
 				},
 				body: JSON.stringify({ name: 'Proxy Allowed' })
@@ -209,9 +207,9 @@ describe('auth', () => {
 			const sameOriginStatus = await callApi(server.app, '/api/auth/status', {
 				headers: {
 					Cookie: session,
-					Host: 'upstream.internal:4000',
+					Host: 'cookbook.example.test:443',
 					Origin: 'https://cookbook.example.test',
-					Forwarded: 'proto=https;host=cookbook.example.test:443'
+					Forwarded: 'proto=https'
 				}
 			});
 			expect(sameOriginStatus.status).toBe(200);
@@ -220,8 +218,8 @@ describe('auth', () => {
 		}
 	});
 
-	test('ignores spoofed forwarded origin headers unless proxy trust is enabled', async () => {
-		const server = await loadServer();
+	test('does not use forwarded host as same-origin evidence', async () => {
+		const server = await loadServer({ TRUST_PROXY_HEADERS: 'true' });
 		try {
 			const login = await callApi(server.app, '/api/auth/login', {
 				method: 'POST',

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -177,7 +177,7 @@ describe('auth', () => {
 	});
 
 	test('allows same-origin API requests when TLS is terminated by a proxy', async () => {
-		const server = await loadServer({ TRUST_PROXY_HEADERS: 'true' });
+		const server = await loadServer();
 		try {
 			const login = await callApi(server.app, '/api/auth/login', {
 				method: 'POST',
@@ -219,7 +219,7 @@ describe('auth', () => {
 	});
 
 	test('does not use forwarded host as same-origin evidence', async () => {
-		const server = await loadServer({ TRUST_PROXY_HEADERS: 'true' });
+		const server = await loadServer();
 		try {
 			const login = await callApi(server.app, '/api/auth/login', {
 				method: 'POST',
@@ -250,7 +250,7 @@ describe('auth', () => {
 			const login = await callApi(server.app, '/api/auth/login', {
 				method: 'POST',
 				headers: {
-					Origin: 'http://localhost',
+					Origin: 'https://localhost',
 					'X-Forwarded-Proto': 'https'
 				},
 				body: JSON.stringify({ username: 'chef', password: 'secret' })

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -177,7 +177,7 @@ describe('auth', () => {
 	});
 
 	test('allows same-origin API requests when TLS is terminated by a proxy', async () => {
-		const server = await loadServer();
+		const server = await loadServer({ TRUST_PROXY_HEADERS: 'true' });
 		try {
 			const login = await callApi(server.app, '/api/auth/login', {
 				method: 'POST',
@@ -215,6 +215,32 @@ describe('auth', () => {
 				}
 			});
 			expect(sameOriginStatus.status).toBe(200);
+		} finally {
+			closeServer(server);
+		}
+	});
+
+	test('ignores spoofed forwarded origin headers unless proxy trust is enabled', async () => {
+		const server = await loadServer();
+		try {
+			const login = await callApi(server.app, '/api/auth/login', {
+				method: 'POST',
+				body: JSON.stringify({ username: 'chef', password: 'secret' })
+			});
+			expect(login.status).toBe(200);
+			const session = cookiePair(login.headers.get('set-cookie'));
+
+			const spoofedForwardedHost = await callApi(server.app, '/api/cookbooks', {
+				headers: {
+					Cookie: session,
+					Host: 'localhost',
+					Origin: 'http://evil.example.test',
+					'X-Forwarded-Host': 'evil.example.test',
+					'X-Forwarded-Proto': 'http'
+				}
+			});
+			expect(spoofedForwardedHost.status).toBe(400);
+			await expect(spoofedForwardedHost.json()).resolves.toEqual({ error: 'cross-origin API request denied' });
 		} finally {
 			closeServer(server);
 		}

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -176,6 +176,36 @@ describe('auth', () => {
 		}
 	});
 
+	test('allows same-origin API requests when TLS is terminated by a proxy', async () => {
+		const server = await loadServer();
+		try {
+			const login = await callApi(server.app, '/api/auth/login', {
+				method: 'POST',
+				headers: {
+					Origin: 'https://localhost',
+					'X-Forwarded-Proto': 'https'
+				},
+				body: JSON.stringify({ username: 'chef', password: 'secret' })
+			});
+			expect(login.status).toBe(200);
+			expect(login.headers.get('set-cookie')).toContain('Secure');
+			const session = cookiePair(login.headers.get('set-cookie'));
+
+			const sameOriginCreate = await callApi(server.app, '/api/cookbooks', {
+				method: 'POST',
+				headers: {
+					Cookie: session,
+					Origin: 'https://localhost',
+					'X-Forwarded-Proto': 'https'
+				},
+				body: JSON.stringify({ name: 'Proxy Allowed' })
+			});
+			expect(sameOriginCreate.status).toBe(200);
+		} finally {
+			closeServer(server);
+		}
+	});
+
 	test('denies cross-origin protected API requests even with a valid auth cookie', async () => {
 		const server = await loadServer();
 		try {

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -246,6 +246,24 @@ describe('auth', () => {
 		}
 	});
 
+	test('sets secure cookies from forwarded proto without trusting forwarded origins', async () => {
+		const server = await loadServer();
+		try {
+			const login = await callApi(server.app, '/api/auth/login', {
+				method: 'POST',
+				headers: {
+					Origin: 'http://localhost',
+					'X-Forwarded-Proto': 'https'
+				},
+				body: JSON.stringify({ username: 'chef', password: 'secret' })
+			});
+			expect(login.status).toBe(200);
+			expect(login.headers.get('set-cookie')).toContain('Secure');
+		} finally {
+			closeServer(server);
+		}
+	});
+
 	test('denies cross-origin protected API requests even with a valid auth cookie', async () => {
 		const server = await loadServer();
 		try {

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -176,6 +176,92 @@ describe('auth', () => {
 		}
 	});
 
+	test('denies cross-origin protected API requests even with a valid auth cookie', async () => {
+		const server = await loadServer();
+		try {
+			const login = await callApi(server.app, '/api/auth/login', {
+				method: 'POST',
+				body: JSON.stringify({ username: 'chef', password: 'secret' })
+			});
+			expect(login.status).toBe(200);
+			const session = cookiePair(login.headers.get('set-cookie'));
+
+			const crossOriginRead = await callApi(server.app, '/api/cookbooks', {
+				headers: {
+					Cookie: session,
+					Origin: 'http://evil.example.test'
+				}
+			});
+			expect(crossOriginRead.status).toBe(400);
+			await expect(crossOriginRead.json()).resolves.toEqual({ error: 'cross-origin API request denied' });
+
+			const crossOriginCreate = await callApi(server.app, '/api/cookbooks', {
+				method: 'POST',
+				headers: {
+					Cookie: session,
+					Origin: 'http://evil.example.test'
+				},
+				body: JSON.stringify({ name: 'Injected' })
+			});
+			expect(crossOriginCreate.status).toBe(400);
+			await expect(crossOriginCreate.json()).resolves.toEqual({ error: 'cross-origin API request denied' });
+
+			const sameOriginCreate = await callApi(server.app, '/api/cookbooks', {
+				method: 'POST',
+				headers: {
+					Cookie: session,
+					Origin: 'http://localhost'
+				},
+				body: JSON.stringify({ name: 'Allowed' })
+			});
+			expect(sameOriginCreate.status).toBe(200);
+		} finally {
+			closeServer(server);
+		}
+	});
+
+	test('denies cross-origin auth status and logout requests with a valid auth cookie', async () => {
+		const server = await loadServer();
+		try {
+			const login = await callApi(server.app, '/api/auth/login', {
+				method: 'POST',
+				body: JSON.stringify({ username: 'chef', password: 'secret' })
+			});
+			expect(login.status).toBe(200);
+			const session = cookiePair(login.headers.get('set-cookie'));
+
+			const crossOriginStatus = await callApi(server.app, '/api/auth/status', {
+				headers: {
+					Cookie: session,
+					Origin: 'http://evil.example.test'
+				}
+			});
+			expect(crossOriginStatus.status).toBe(400);
+			await expect(crossOriginStatus.json()).resolves.toEqual({ error: 'cross-origin API request denied' });
+
+			const crossOriginLogout = await callApi(server.app, '/api/auth/logout', {
+				method: 'POST',
+				headers: {
+					Cookie: session,
+					Origin: 'http://evil.example.test'
+				}
+			});
+			expect(crossOriginLogout.status).toBe(400);
+			await expect(crossOriginLogout.json()).resolves.toEqual({ error: 'cross-origin API request denied' });
+
+			const sameOriginStatus = await callApi(server.app, '/api/auth/status', {
+				headers: {
+					Cookie: session,
+					Origin: 'http://localhost'
+				}
+			});
+			expect(sameOriginStatus.status).toBe(200);
+			await expect(sameOriginStatus.json()).resolves.toEqual({ enabled: true, authenticated: true, username: 'chef' });
+		} finally {
+			closeServer(server);
+		}
+	});
+
 	test('keeps health endpoints publicly accessible when auth is enabled', async () => {
 		const server = await loadServer();
 		try {


### PR DESCRIPTION
## Summary

Fixes a CSRF/CORS issue in the cookie-authenticated API by rejecting browser requests with a cross-origin `Origin` header when shared authentication is enabled.

## Changes

- Adds same-origin enforcement for protected cookbook, recipe, tag, and ingredient APIs.
- Applies the same same-origin check to `/api/auth/*` cookie-backed auth routes.
- Preserves CORS preflight behavior and non-browser/API clients that do not send an `Origin` header.
- Adds server auth tests covering cross-origin read, mutation, auth status, and logout denial with a valid auth cookie.

## Root Cause

The app used an HttpOnly `SameSite=Lax` auth cookie with permissive credentialed CORS and no same-origin/CSRF validation on protected API requests. SameSite is site-based, not origin-based, so same-site cross-origin pages could still send credentialed API requests.

## Validation

- `bun --env-file=.env.test test tests/server/auth.test.ts`
- `bun run lint`
- `bun run test`
- `bun run build`