### PR TITLE
Set SQLite synchronous mode to NORMAL for faster UI updates

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -163,6 +163,7 @@ const staticBasePath = normalizeStaticBasePath(process.env.COOKBOOK_BASE_PATH ??
 const db = new Database(resolvedDbPath, { create: true });
 export const database = db;
 db.exec('PRAGMA journal_mode = WAL;');
+db.exec('PRAGMA synchronous = NORMAL;');
 db.exec('PRAGMA foreign_keys = ON;');
 
 type StatementType = ReturnType<Database['prepare']>;


### PR DESCRIPTION
## Summary
- Lower SQLite write durability from the default to `NORMAL` on startup.
- Reduce database write latency so UI update flows complete faster.
- Keep the existing WAL and foreign key pragmas intact.

## Testing
- Not run (not requested)