### PR TITLE
Return recipe tags in alphabetical order

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -915,7 +915,8 @@ const fetchTags = (ids: number[]) => {
 	const rows = allStatement<{ recipeId: number; name: string }>(
 		`SELECT rt.recipe_id as recipeId, t.name as name
 		 FROM recipe_tags rt JOIN tags t ON t.id = rt.tag_id
-		 WHERE rt.recipe_id IN (${placeholders})`,
+		 WHERE rt.recipe_id IN (${placeholders})
+		 ORDER BY rt.recipe_id ASC, t.name COLLATE NOCASE ASC, t.name ASC`,
 		...ids
 	);
 	return mapRows(rows);
@@ -1166,7 +1167,10 @@ export const app = new Elysia({
 		);
 		const noteRow = getStatement<{ content: string }>('SELECT content FROM notes WHERE recipe_id=?', id);
 		const tags = allStatement<{ name: string }>(
-			'SELECT t.name FROM recipe_tags rt JOIN tags t ON t.id = rt.tag_id WHERE rt.recipe_id=?',
+			`SELECT t.name
+			 FROM recipe_tags rt JOIN tags t ON t.id = rt.tag_id
+			 WHERE rt.recipe_id=?
+			 ORDER BY t.name COLLATE NOCASE ASC, t.name ASC`,
 			id
 		).map((row) => row.name);
 		const likes = allStatement<{ name: string }>(

--- a/tests/server/index.test.ts
+++ b/tests/server/index.test.ts
@@ -115,6 +115,47 @@ test('recipe create rejects thumbnail-only photo payloads', async () => {
 	await expect(res.json()).resolves.toEqual({ error: 'photoThumbnailDataUrl requires supplied photoDataUrl' });
 });
 
+test('recipe tags are returned alphabetically from recipe endpoints', async () => {
+	const createRes = await callApi('/api/recipes', {
+		method: 'POST',
+		body: JSON.stringify({
+			cookbook_id: 1,
+			title: 'Sorted Tag Recipe',
+			description: '',
+			author: '',
+			ingredients: [],
+			steps: [],
+			notes: '',
+			tags: ['zucchini', 'Breakfast', 'apple']
+		})
+	});
+	expect(createRes.status).toBe(200);
+	const { id } = (await createRes.json()) as { id: number };
+
+	const addTagRes = await callApi(`/api/recipes/${id}/tags`, {
+		method: 'POST',
+		body: JSON.stringify({ name: 'Dinner' })
+	});
+	expect(addTagRes.status).toBe(200);
+
+	const expectedTags = ['apple', 'Breakfast', 'Dinner', 'zucchini'];
+
+	const listRes = await callApi('/api/recipes?cookbookId=1');
+	expect(listRes.status).toBe(200);
+	const listPayload = (await listRes.json()) as Array<{ id: number; tags: string[] }>;
+	expect(listPayload.find((recipe) => recipe.id === id)?.tags).toEqual(expectedTags);
+
+	const searchRes = await callApi('/api/recipes/search?cookbookId=1&q=Sorted');
+	expect(searchRes.status).toBe(200);
+	const searchPayload = (await searchRes.json()) as Array<{ id: number; tags: string[] }>;
+	expect(searchPayload.find((recipe) => recipe.id === id)?.tags).toEqual(expectedTags);
+
+	const detailRes = await callApi(`/api/recipes/${id}`);
+	expect(detailRes.status).toBe(200);
+	const detailPayload = (await detailRes.json()) as { tags: string[] };
+	expect(detailPayload.tags).toEqual(expectedTags);
+});
+
 test('recipe photo endpoints reject unsafe MIME types and do not echo legacy unsafe types', async () => {
 	const parameterizedCreate = await callApi('/api/recipes', {
 		method: 'POST',


### PR DESCRIPTION
## Summary
- Sort recipe tags case-insensitively in both list and detail queries.
- Add server tests to verify tag order is stable across create, list, search, and detail endpoints.

## Testing
- Added integration coverage for recipe tag ordering.
- Not run (not requested).