### PR TITLE
Add like-based recipe filtering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,6 +90,8 @@ function App() {
 	const [tagMode, setTagMode] = useState<FilterMode>('AND');
 	const [selectedIngredients, setSelectedIngredients] = useState<string[]>([]);
 	const [ingredientMode, setIngredientMode] = useState<FilterMode>('AND');
+	const [selectedLikes, setSelectedLikes] = useState<string[]>([]);
+	const [likeMode, setLikeMode] = useState<FilterMode>('AND');
 	const [sortMode, setSortMode] = useState<SortMode>('AZ');
 	const [theme, setTheme] = useState<'light' | 'dark'>(() => {
 		if (typeof localStorage !== 'undefined') {
@@ -195,9 +197,10 @@ function App() {
 		setAllRecipes([]);
 		setSelectedTags([]);
 		setSelectedIngredients([]);
+		setSelectedLikes([]);
 	}, [authStatus]);
 	useEffect(() => { reload(); }, [reload]);
-	useEffect(() => { setSelectedTags([]); setSelectedIngredients([]); }, [activeCookbook]);
+	useEffect(() => { setSelectedTags([]); setSelectedIngredients([]); setSelectedLikes([]); }, [activeCookbook]);
 	useEffect(() => {
 		if (!queryEffectInitializedRef.current) {
 			queryEffectInitializedRef.current = true;
@@ -218,6 +221,11 @@ function App() {
 		allRecipes.forEach(r => (r.ingredientNames || []).forEach((ing: string) => set.add(ing)));
 		return Array.from(set).sort((a, b) => a.localeCompare(b));
 	}, [allRecipes]);
+	const allLikes = useMemo(() => {
+		const set = new Set<string>();
+		allRecipes.forEach(r => (r.likes || []).forEach((name: string) => set.add(name)));
+		return Array.from(set).sort((a, b) => a.localeCompare(b));
+	}, [allRecipes]);
 	const filtered = useMemo(
 		() =>
 			filterAndSortRecipes(allRecipes, {
@@ -225,9 +233,11 @@ function App() {
 				tagMode,
 				selectedIngredients,
 				ingredientMode,
+				selectedLikes,
+				likeMode,
 				sortMode
 			}),
-		[allRecipes, selectedTags, tagMode, selectedIngredients, ingredientMode, sortMode]
+		[allRecipes, selectedTags, tagMode, selectedIngredients, ingredientMode, selectedLikes, likeMode, sortMode]
 	);
 	useEffect(() => {
 		if (typeof document === 'undefined') return;
@@ -249,6 +259,9 @@ function App() {
 	};
 	const toggleIngredient = (value: string) => {
 		setSelectedIngredients(prev => prev.includes(value) ? prev.filter(x => x !== value) : [...prev, value]);
+	};
+	const toggleLike = (value: string) => {
+		setSelectedLikes(prev => prev.includes(value) ? prev.filter(x => x !== value) : [...prev, value]);
 	};
 	if (!authStatus) {
 		return (
@@ -354,6 +367,30 @@ function App() {
 						</div>
 						{selectedIngredients.length > 0 && (
 							<button onClick={()=>setSelectedIngredients([])} className="self-start text-xs text-muted-foreground hover:text-foreground underline">Clear ingredients</button>
+						)}
+						<div className="border-t border-border/70 my-4" />
+						<div className="flex items-center justify-between">
+							<Label className="text-xs uppercase font-semibold tracking-wide text-black dark:text-muted-foreground">Like Filter</Label>
+							<div className="flex gap-1 rounded border overflow-hidden">
+								{(['AND','OR'] as const).map(m => (
+									<button key={m} onClick={()=>setLikeMode(m)} className={`px-2 py-1 text-[11px] font-medium ${likeMode===m?'bg-accent text-accent-foreground':'text-muted-foreground hover:bg-accent/40'}`}>{m}</button>
+								))}
+							</div>
+						</div>
+						<div className="flex flex-wrap gap-1">
+							{allLikes.map(name => {
+								const selected = selectedLikes.includes(name);
+								const style = computePillStyle(name, selected, theme);
+								return (
+									<button key={name} onClick={()=>toggleLike(name)} style={style} className={`text-[11px] px-2.5 py-0.5 rounded-full border leading-none transition-colors ${selected?'ring-1 ring-border':''}`}>{name}</button>
+								);
+							})}
+							{!allLikes.length && (
+								<p className="text-xs text-muted-foreground">No likes yet</p>
+							)}
+						</div>
+						{selectedLikes.length > 0 && (
+							<button onClick={()=>setSelectedLikes([])} className="self-start text-xs text-muted-foreground hover:text-foreground underline">Clear likes</button>
 						)}
 					</aside>
 				</main>

--- a/src/lib/filters.ts
+++ b/src/lib/filters.ts
@@ -6,6 +6,7 @@ export type FilterableRecipe = {
 	title: string;
 	uses: number;
 	tags: string[];
+	likes: string[];
 	ingredientNames: string[];
 };
 
@@ -14,6 +15,8 @@ type Options = {
 	tagMode: FilterMode;
 	selectedIngredients: string[];
 	ingredientMode: FilterMode;
+	selectedLikes: string[];
+	likeMode: FilterMode;
 	sortMode: SortMode;
 };
 
@@ -24,12 +27,14 @@ const matchesValues = (haystack: string[], needles: string[], mode: FilterMode) 
 };
 
 export function filterAndSortRecipes<T extends FilterableRecipe>(recipes: T[], options: Options): T[] {
-	const { selectedTags, tagMode, selectedIngredients, ingredientMode, sortMode } = options;
+	const { selectedTags, tagMode, selectedIngredients, ingredientMode, selectedLikes, likeMode, sortMode } = options;
 	const filtered = recipes.filter((r) => {
 		const matchesTags = matchesValues(r.tags || [], selectedTags, tagMode);
 		if (!matchesTags) return false;
 		const matchesIngredients = matchesValues(r.ingredientNames || [], selectedIngredients, ingredientMode);
-		return matchesIngredients;
+		if (!matchesIngredients) return false;
+		const matchesLikes = matchesValues(r.likes || [], selectedLikes, likeMode);
+		return matchesLikes;
 	});
 	const sorted = [...filtered].sort((a, b) => {
 		if (sortMode === 'AZ') return a.title.localeCompare(b.title);

--- a/tests/lib/filters.test.ts
+++ b/tests/lib/filters.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from 'bun:test';
 import { filterAndSortRecipes, type FilterableRecipe } from '@/lib/filters';
 
 const recipes = [
-	{ id: 1, title: 'Alpha', uses: 5, tags: ['vegan'], ingredientNames: ['garlic', 'salt'] },
-	{ id: 2, title: 'Beta', uses: 3, tags: ['italian'], ingredientNames: ['garlic'] },
-	{ id: 3, title: 'Gamma', uses: 7, tags: ['vegan', 'italian'], ingredientNames: ['garlic', 'tomato'] },
-	{ id: 4, title: 'Delta', uses: 1, tags: [], ingredientNames: ['basil'] },
-	{ id: 5, title: 'Eclair', uses: 5, tags: [], ingredientNames: ['flour'] }
+	{ id: 1, title: 'Alpha', uses: 5, tags: ['vegan'], likes: ['Alex', 'Mira'], ingredientNames: ['garlic', 'salt'] },
+	{ id: 2, title: 'Beta', uses: 3, tags: ['italian'], likes: ['Sam'], ingredientNames: ['garlic'] },
+	{ id: 3, title: 'Gamma', uses: 7, tags: ['vegan', 'italian'], likes: ['Alex', 'Sam'], ingredientNames: ['garlic', 'tomato'] },
+	{ id: 4, title: 'Delta', uses: 1, tags: [], likes: ['Mira'], ingredientNames: ['basil'] },
+	{ id: 5, title: 'Eclair', uses: 5, tags: [], likes: [], ingredientNames: ['flour'] }
 ] satisfies ReadonlyArray<FilterableRecipe>;
 
 describe('filterAndSortRecipes', () => {
@@ -16,6 +16,8 @@ describe('filterAndSortRecipes', () => {
 			tagMode: 'AND',
 			selectedIngredients: ['garlic', 'tomato'],
 			ingredientMode: 'AND',
+			selectedLikes: [],
+			likeMode: 'AND',
 			sortMode: 'AZ'
 		});
 		expect(result.map((r) => r.title)).toEqual(['Gamma']);
@@ -27,9 +29,35 @@ describe('filterAndSortRecipes', () => {
 			tagMode: 'AND',
 			selectedIngredients: ['basil', 'salt'],
 			ingredientMode: 'OR',
+			selectedLikes: [],
+			likeMode: 'AND',
 			sortMode: 'AZ'
 		});
 		expect(result.map((r) => r.title)).toEqual(['Alpha', 'Delta']);
+	});
+
+	test('supports AND and OR filtering by likes', () => {
+		const andResult = filterAndSortRecipes(recipes, {
+			selectedTags: [],
+			tagMode: 'AND',
+			selectedIngredients: [],
+			ingredientMode: 'AND',
+			selectedLikes: ['Alex', 'Sam'],
+			likeMode: 'AND',
+			sortMode: 'AZ'
+		});
+		expect(andResult.map((r) => r.title)).toEqual(['Gamma']);
+
+		const orResult = filterAndSortRecipes(recipes, {
+			selectedTags: [],
+			tagMode: 'AND',
+			selectedIngredients: [],
+			ingredientMode: 'AND',
+			selectedLikes: ['Mira', 'Sam'],
+			likeMode: 'OR',
+			sortMode: 'AZ'
+		});
+		expect(orResult.map((r) => r.title)).toEqual(['Alpha', 'Beta', 'Delta', 'Gamma']);
 	});
 
 	test('sorts by MOST cooked with title tiebreaker', () => {
@@ -38,6 +66,8 @@ describe('filterAndSortRecipes', () => {
 			tagMode: 'AND',
 			selectedIngredients: [],
 			ingredientMode: 'AND',
+			selectedLikes: [],
+			likeMode: 'AND',
 			sortMode: 'MOST'
 		});
 		expect(result.map((r) => r.title)).toEqual(['Gamma', 'Alpha', 'Eclair', 'Beta', 'Delta']);


### PR DESCRIPTION
## Summary
- Add a likes filter section to the recipe sidebar with AND/OR matching
- Include likes in client-side recipe filtering and derived filter options
- Expand filter tests to cover like-based AND/OR behavior

## Testing
- Added unit coverage for likes filtering and existing sort cases
- Not run (not requested)