### PR TITLE
Add saved-like autocomplete and like name suggestions

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -86,11 +86,12 @@ const cookbookMutationSchema = z.object({ name: nonEmptyString.max(255) });
 const idParamSchema = z.object({ id: z.coerce.number().int().positive() });
 const cookbookQuerySchema = z.object({ cookbookId: z.coerce.number().int().positive() });
 const recipeSearchSchema = cookbookQuerySchema.extend({ q: z.string().optional() });
-const ingredientsQuerySchema = z.object({
+const nameSuggestionsQuerySchema = z.object({
 	cookbookId: z.coerce.number().int().positive().optional(),
 	q: z.string().optional(),
 	limit: z.coerce.number().int().positive().max(5000).optional()
 });
+const ingredientsQuerySchema = nameSuggestionsQuerySchema;
 const nameSchema = z.object({ name: nonEmptyString.max(255) });
 const usesDeltaSchema = z.object({ delta: z.number().int().min(-1000).max(1000) }).strict();
 const loginSchema = z
@@ -532,7 +533,7 @@ type AuthSession = {
 	username?: string;
 };
 
-const protectedPrefixes = ['/api/cookbooks', '/api/recipes', '/api/tags', '/api/ingredients'];
+const protectedPrefixes = ['/api/cookbooks', '/api/recipes', '/api/tags', '/api/ingredients', '/api/likes'];
 
 const isProtectedApiPath = (pathname: string) =>
 	protectedPrefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
@@ -1490,6 +1491,73 @@ export const app = new Elysia({
 		} catch {
 			set.status = 500;
 			return { error: 'failed to fetch ingredients' };
+		}
+	})
+	.get('/api/likes', ({ query, set }) => {
+		const parsed = nameSuggestionsQuerySchema.safeParse(query);
+		if (!parsed.success) return validationError(set, parsed.error);
+
+		try {
+			const { cookbookId, limit } = parsed.data;
+			const rawTerm = (parsed.data.q ?? '').trim().toLowerCase();
+			const hasTerm = rawTerm.length > 0;
+			const escapedTerm = rawTerm.replace(/[%_]/g, '\\$&');
+			const likeTerm = `%${escapedTerm}%`;
+			const prefixTerm = `${escapedTerm}%`;
+
+			const whereParts: string[] = [];
+			const params: (string | number)[] = [];
+
+			let joinClause = '';
+			if (cookbookId != null) {
+				joinClause = 'JOIN recipes r ON r.id = rl.recipe_id';
+				whereParts.push('r.cookbook_id = ?');
+				params.push(cookbookId);
+			}
+
+			if (hasTerm) {
+				whereParts.push(`LOWER(rl.name) LIKE ? ESCAPE '\\'`);
+				params.push(likeTerm);
+			}
+
+			const whereClause = whereParts.length ? `WHERE ${whereParts.join(' AND ')}` : '';
+			const limitClause = limit != null ? 'LIMIT ?' : '';
+
+			const orderClause = hasTerm
+				? `
+					ORDER BY
+						CASE
+							WHEN LOWER(rl.name) = ? THEN 0
+							WHEN LOWER(rl.name) LIKE ? ESCAPE '\\' THEN 1
+							ELSE 2
+						END,
+						LENGTH(rl.name) ASC,
+						rl.name COLLATE NOCASE ASC
+				`
+				: 'ORDER BY rl.name COLLATE NOCASE ASC';
+
+			if (hasTerm) {
+				params.push(rawTerm, prefixTerm);
+			}
+			if (limit != null) {
+				params.push(limit);
+			}
+
+			const rows = allStatement<{ name: string }>(
+				`
+				SELECT DISTINCT rl.name as name
+				FROM recipe_likes rl
+				${joinClause}
+				${whereClause}
+				${orderClause}
+				${limitClause}
+				`,
+				...params
+			);
+			return rows.map((r) => r.name);
+		} catch {
+			set.status = 500;
+			return { error: 'failed to fetch likes' };
 		}
 	});
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -300,7 +300,7 @@ function App() {
 				<main className="flex flex-1 overflow-hidden">
 					<div className="flex-1 p-6 overflow-auto">
 						{activeCookbook && (
-							<AnimatedRecipeGrid recipes={filtered} onChange={reload} onUsesChange={updateRecipeUses} cookbookId={activeCookbook} />
+							<AnimatedRecipeGrid recipes={filtered} onChange={reload} onUsesChange={updateRecipeUses} cookbookId={activeCookbook} likeSuggestions={allLikes} />
 						)}
 					</div>
 					<aside className="w-72 border-l border-border p-4 flex flex-col gap-4 bg-sidebar/60 backdrop-blur supports-[backdrop-filter]:bg-sidebar/40 overflow-y-auto">
@@ -403,12 +403,14 @@ function AnimatedRecipeGrid({
 	recipes,
 	onChange,
 	onUsesChange,
-	cookbookId
+	cookbookId,
+	likeSuggestions
 }: {
 	recipes: Recipe[];
 	onChange: () => Promise<void> | void;
 	onUsesChange: (recipeId: number, uses: number) => void;
 	cookbookId: number;
+	likeSuggestions: string[];
 }) {
 	const EXIT_MS = 300;
 	const items = useAnimatedItems(recipes, EXIT_MS);
@@ -433,7 +435,7 @@ function AnimatedRecipeGrid({
 						className={common + ' surface-transition'}
 						style={style}
 					>
-						<RecipeCard recipe={it.recipe} onChange={() => { void onChange(); }} onUsesChange={onUsesChange} />
+						<RecipeCard recipe={it.recipe} onChange={() => { void onChange(); }} onUsesChange={onUsesChange} likeSuggestions={likeSuggestions} />
 					</div>
 				);
 			})}

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { updateUsesDelta, getRecipe, updateRecipe, addTagToRecipe, removeTagFromRecipe, addLike, removeLike, deleteRecipe, listTags, listIngredients, type StructuredIngredient } from '../lib/api';
+import { updateUsesDelta, getRecipe, updateRecipe, addTagToRecipe, removeTagFromRecipe, addLike, removeLike, deleteRecipe, listTags, listIngredients, listLikes, type StructuredIngredient } from '../lib/api';
 import { loadImageDataUrl, selectPhotoThumbnailDataUrl, THUMBNAIL_MAX_DIMENSION } from '../lib/image';
 import { useReorderDrag } from '../hooks/useReorderDrag';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from './ui/select';
@@ -39,6 +39,7 @@ interface RecipeDetail extends RecipeSummary {
 
 type EditableIngredient = BaseIngredient & { _k: string };
 type EditableStep = { _k: string; text: string };
+const EMPTY_LIKE_SUGGESTIONS: string[] = [];
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
 const isFiniteNumber = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value);
@@ -53,6 +54,27 @@ const uniqNames = (list: string[]) => {
 		result.push(name.trim());
 	}
 	return result;
+};
+
+const filterNameSuggestions = (list: string[], query: string) => {
+	const q = query.trim().toLowerCase();
+	const names = uniqNames(list);
+	if (!q) return names.slice(0, 50);
+	return names
+		.filter(name => name.toLowerCase().includes(q))
+		.map(name => {
+			const lower = name.toLowerCase();
+			let score = 0;
+			if (lower === q) score += 100;
+			if (lower.startsWith(q)) score += 50;
+			const idx = lower.indexOf(q);
+			score += Math.max(0, 30 - idx);
+			score -= Math.max(0, lower.length - q.length);
+			return { name, score };
+		})
+		.sort((a, b) => b.score - a.score)
+		.map(entry => entry.name)
+		.slice(0, 50);
 };
 
 const normalizeIngredients = (ingredients?: unknown): BaseIngredient[] => {
@@ -113,9 +135,10 @@ interface RecipeCardProps {
 	recipe: RecipeSummary;
 	onChange: () => void;
 	onUsesChange?: (recipeId: number, uses: number) => void;
+	likeSuggestions?: string[];
 }
 
-export function RecipeCard({ recipe, onChange, onUsesChange }: RecipeCardProps) {
+export function RecipeCard({ recipe, onChange, onUsesChange, likeSuggestions = EMPTY_LIKE_SUGGESTIONS }: RecipeCardProps) {
 	const [likes, setLikes] = useState<string[]>(uniqNames(recipe.likes || []));
 	const [usesCount, setUsesCount] = useState<number>(recipe.uses ?? 0);
 	const usesCountRef = useRef(recipe.uses ?? 0);
@@ -251,8 +274,14 @@ export function RecipeCard({ recipe, onChange, onUsesChange }: RecipeCardProps) 
 	const photoInputRef = useRef<HTMLInputElement | null>(null);
 	const [quickLikeActive, setQuickLikeActive] = useState(false);
 	const [quickLikeValue, setQuickLikeValue] = useState('');
+	const [filteredQuickLikeNames, setFilteredQuickLikeNames] = useState<string[]>([]);
+	const [quickLikeHighlight, setQuickLikeHighlight] = useState<number>(-1);
+	const [quickLikeSuggestionsNode, setQuickLikeSuggestionsNode] = useState<HTMLElement | null>(null);
 	const [addingLike, setAddingLike] = useState(false);
 	const [likeValue, setLikeValue] = useState('');
+	const [filteredLikeNames, setFilteredLikeNames] = useState<string[]>([]);
+	const [likeHighlight, setLikeHighlight] = useState<number>(-1);
+	const [likeSuggestionsNode, setLikeSuggestionsNode] = useState<HTMLElement | null>(null);
 	const likeInputRef = useRef<HTMLInputElement | null>(null);
 	const quickLikeInputRef = useRef<HTMLInputElement | null>(null);
 	useEffect(() => {
@@ -260,8 +289,79 @@ export function RecipeCard({ recipe, onChange, onUsesChange }: RecipeCardProps) 
 			quickLikeInputRef.current?.focus();
 		} else {
 			setQuickLikeValue('');
+			setFilteredQuickLikeNames([]);
+			setQuickLikeHighlight(-1);
 		}
 	}, [quickLikeActive]);
+	useEffect(() => {
+		if (!quickLikeActive) return;
+		let active = true;
+		const localSuggestions = filterNameSuggestions(likeSuggestions, quickLikeValue);
+		setFilteredQuickLikeNames(localSuggestions);
+		const h = setTimeout(() => {
+			(async () => {
+				try {
+					const names = await listLikes({ cookbookId: recipe.cookbook_id, q: quickLikeValue.trim(), limit: 50 });
+					if (!active) return;
+					setFilteredQuickLikeNames(names);
+				} catch (error) {
+					if (!active) return;
+					setFilteredQuickLikeNames(localSuggestions);
+					console.error('Failed to load like suggestions', error);
+				}
+			})();
+		}, 80);
+		return () => { active = false; clearTimeout(h); };
+	}, [quickLikeActive, quickLikeValue, recipe.cookbook_id, likeSuggestions]);
+	useEffect(() => { setQuickLikeHighlight(-1); }, [filteredQuickLikeNames]);
+	useEffect(() => {
+		if (quickLikeHighlight < 0 || !quickLikeSuggestionsNode) return;
+		const container = quickLikeSuggestionsNode;
+		const el = container.querySelector(`[data-idx="${quickLikeHighlight}"]`) as HTMLElement | null;
+		if (!el) return;
+		const top = el.offsetTop;
+		const bottom = top + el.offsetHeight;
+		if (top < container.scrollTop) container.scrollTop = top;
+		else if (bottom > container.scrollTop + container.clientHeight) container.scrollTop = bottom - container.clientHeight;
+	}, [quickLikeHighlight, quickLikeSuggestionsNode]);
+	useEffect(() => {
+		if (!addingLike) {
+			setLikeValue('');
+			setFilteredLikeNames([]);
+			setLikeHighlight(-1);
+		}
+	}, [addingLike]);
+	useEffect(() => {
+		if (!addingLike) return;
+		let active = true;
+		const localSuggestions = filterNameSuggestions(likeSuggestions, likeValue);
+		setFilteredLikeNames(localSuggestions);
+		const h = setTimeout(() => {
+			(async () => {
+				try {
+					const names = await listLikes({ cookbookId: recipe.cookbook_id, q: likeValue.trim(), limit: 50 });
+					if (!active) return;
+					setFilteredLikeNames(names);
+				} catch (error) {
+					if (!active) return;
+					setFilteredLikeNames(localSuggestions);
+					console.error('Failed to load like suggestions', error);
+				}
+			})();
+		}, 80);
+		return () => { active = false; clearTimeout(h); };
+	}, [addingLike, likeValue, recipe.cookbook_id, likeSuggestions]);
+	useEffect(() => { setLikeHighlight(-1); }, [filteredLikeNames]);
+	useEffect(() => {
+		if (likeHighlight < 0 || !likeSuggestionsNode) return;
+		const container = likeSuggestionsNode;
+		const el = container.querySelector(`[data-idx="${likeHighlight}"]`) as HTMLElement | null;
+		if (!el) return;
+		const top = el.offsetTop;
+		const bottom = top + el.offsetHeight;
+		if (top < container.scrollTop) container.scrollTop = top;
+		else if (bottom > container.scrollTop + container.clientHeight) container.scrollTop = bottom - container.clientHeight;
+	}, [likeHighlight, likeSuggestionsNode]);
 	const [filteredIngredients, setFilteredIngredients] = useState<string[]>([]);
 	const [activeIngredientIndex, setActiveIngredientIndex] = useState<number | null>(null);
 	const [ingredientAnchor, setIngredientAnchor] = useState<HTMLInputElement | null>(null);
@@ -509,9 +609,9 @@ export function RecipeCard({ recipe, onChange, onUsesChange }: RecipeCardProps) 
 		},
 		[fetchAndApplyDetail, full, likes, onChange, pullLike, pushLike, recipe.id]
 	);
-	const addLikeInline = async () => {
-		if (!full || !likeValue.trim()) return;
-		const name = likeValue.trim();
+	const addLikeInline = async (nameOverride?: string) => {
+		const name = (nameOverride ?? likeValue).trim();
+		if (!full || !name) return;
 		setLikeValue('');
 		setAddingLike(false);
 		await persistLike(name, full.id);
@@ -537,6 +637,37 @@ export function RecipeCard({ recipe, onChange, onUsesChange }: RecipeCardProps) 
 	const cancelQuickLike = () => {
 		setQuickLikeActive(false);
 		setQuickLikeValue('');
+	};
+	const onKeyDownQuickLike = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			cancelQuickLike();
+		} else if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			setQuickLikeHighlight(h => Math.min(filteredQuickLikeNames.length - 1, h + 1));
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			setQuickLikeHighlight(h => Math.max(-1, h - 1));
+		} else if (e.key === 'Enter' && quickLikeHighlight >= 0 && filteredQuickLikeNames[quickLikeHighlight]) {
+			e.preventDefault();
+			void handleQuickLikeSubmit(filteredQuickLikeNames[quickLikeHighlight]);
+		}
+	};
+	const onKeyDownLike = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			setLikeValue('');
+			setAddingLike(false);
+		} else if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			setLikeHighlight(h => Math.min(filteredLikeNames.length - 1, h + 1));
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			setLikeHighlight(h => Math.max(-1, h - 1));
+		} else if (e.key === 'Enter' && likeHighlight >= 0 && filteredLikeNames[likeHighlight]) {
+			e.preventDefault();
+			void addLikeInline(filteredLikeNames[likeHighlight]);
+		}
 	};
 	const onPickImage = useCallback((file?: File) => {
 		if (!file) return;
@@ -810,12 +941,9 @@ export function RecipeCard({ recipe, onChange, onUsesChange }: RecipeCardProps) 
 								<Input
 									ref={quickLikeInputRef}
 									name="name"
-									onKeyDown={(e) => {
-										if (e.key === 'Escape') {
-											e.preventDefault();
-											cancelQuickLike();
-										}
-									}}
+									value={quickLikeValue}
+									onChange={(e) => setQuickLikeValue(e.target.value)}
+									onKeyDown={onKeyDownQuickLike}
 									placeholder="Name who likes this"
 									className="h-7 flex-1 min-w-0 text-[11px] px-2"
 								/>
@@ -834,6 +962,19 @@ export function RecipeCard({ recipe, onChange, onUsesChange }: RecipeCardProps) 
 								>
 									Cancel
 								</Button>
+								{quickLikeInputRef.current && (filteredQuickLikeNames.length > 0 || quickLikeValue.trim()) && createPortal(
+									<TagSuggestions
+										anchor={quickLikeInputRef.current}
+										items={filteredQuickLikeNames}
+										highlight={quickLikeHighlight}
+										onHighlight={setQuickLikeHighlight}
+										existing={likes}
+										onPick={(name) => { void handleQuickLikeSubmit(name); }}
+										query={quickLikeValue.trim()}
+										allTags={filteredQuickLikeNames}
+										onContainerChange={setQuickLikeSuggestionsNode}
+									/>, document.body
+								)}
 							</form>
 						) : (
 							<button
@@ -1211,16 +1352,24 @@ export function RecipeCard({ recipe, onChange, onUsesChange }: RecipeCardProps) 
 													autoFocus
 													value={likeValue}
 													onChange={e => setLikeValue(e.target.value)}
-													onKeyDown={e => {
-														if (e.key === 'Escape') {
-															setLikeValue('');
-															setAddingLike(false);
-														}
-													}}
+													onKeyDown={onKeyDownLike}
 													placeholder="Name who likes this"
 													className="h-7 text-xs px-2 w-44"
 												/>
 												<Button type="submit" className="h-7 px-3 text-xs" disabled={!likeValue.trim()}>Add</Button>
+												{likeInputRef.current && (filteredLikeNames.length > 0 || likeValue.trim()) && createPortal(
+													<TagSuggestions
+														anchor={likeInputRef.current}
+														items={filteredLikeNames}
+														highlight={likeHighlight}
+														onHighlight={setLikeHighlight}
+														existing={likes}
+														onPick={(name) => { void addLikeInline(name); }}
+														query={likeValue.trim()}
+														allTags={filteredLikeNames}
+														onContainerChange={setLikeSuggestionsNode}
+													/>, document.body
+												)}
 											</form>
 										) : (
 											<button

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -226,3 +226,12 @@ export async function listIngredients(options?: { cookbookId?: number; q?: strin
 	const suffix = params.toString();
 	return requestJson<string[]>(`${base}/ingredients${suffix ? `?${suffix}` : ''}`);
 }
+
+export async function listLikes(options?: { cookbookId?: number; q?: string; limit?: number }): Promise<string[]> {
+	const params = new URLSearchParams();
+	if (options?.cookbookId != null) params.set('cookbookId', String(options.cookbookId));
+	if (options?.q != null) params.set('q', options.q);
+	if (options?.limit != null) params.set('limit', String(options.limit));
+	const suffix = params.toString();
+	return requestJson<string[]>(`${base}/likes${suffix ? `?${suffix}` : ''}`);
+}

--- a/tests/components/RecipeCard.test.tsx
+++ b/tests/components/RecipeCard.test.tsx
@@ -22,6 +22,7 @@ Object.assign(globalThis, {
 	InputEvent: globalWindow.InputEvent,
 	KeyboardEvent: globalWindow.KeyboardEvent,
 	MouseEvent: globalWindow.MouseEvent,
+	PointerEvent: globalWindow.PointerEvent,
 	SubmitEvent: globalWindow.SubmitEvent,
 	FormData: globalWindow.FormData,
 });
@@ -94,7 +95,7 @@ describe('RecipeCard', () => {
 	});
 
 	test('does not remove an existing like when duplicate quick-like submission would fail', async () => {
-		const fetchMock = mock(() => Promise.reject(new Error('network fail')));
+		const fetchMock = mock(() => Promise.resolve(json(['Alex'])));
 		const originalFetch = globalThis.fetch;
 		globalThis.fetch = fetchMock as unknown as typeof fetch;
 		const originalConsoleError = console.error;
@@ -116,10 +117,45 @@ describe('RecipeCard', () => {
 				expect(queryByPlaceholderText('Name who likes this')).toBeNull();
 			});
 			expect(getByText('Alex')).toBeTruthy();
-			expect(fetchMock).toHaveBeenCalledTimes(0);
+			const postCalls = fetchMock.mock.calls.filter(([input, init]) => {
+				const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+				return url.endsWith('/api/recipes/1/likes') && init?.method === 'POST';
+			});
+			expect(postCalls).toHaveLength(0);
 		} finally {
 			globalThis.fetch = originalFetch;
 			console.error = originalConsoleError;
+		}
+	});
+
+	test('shows saved like names in quick-like autocomplete', async () => {
+		const fetchMock = mock((input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+			if (url.startsWith('/api/likes')) return Promise.resolve(json(['Sam']));
+			if (url.endsWith('/api/recipes/1/likes') && init?.method === 'POST') return Promise.resolve(json({ ok: true }));
+			return Promise.resolve(json({ ok: true }));
+		});
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		try {
+			const { getByText, queryByPlaceholderText } = render(
+				<RecipeCard recipe={{ ...baseRecipe }} onChange={() => {}} />
+			);
+
+			fireEvent.click(getByText('like'));
+
+			await waitFor(() => {
+				expect(getByText('Sam')).toBeTruthy();
+			});
+			fireEvent.pointerDown(getByText('Sam'));
+
+			await waitFor(() => {
+				expect(queryByPlaceholderText('Name who likes this')).toBeNull();
+			});
+			expect(getByText('Sam')).toBeTruthy();
+		} finally {
+			globalThis.fetch = originalFetch;
 		}
 	});
 

--- a/tests/server/index.test.ts
+++ b/tests/server/index.test.ts
@@ -789,6 +789,91 @@ test('ingredients endpoint returns catalogued names without duplicates', async (
 	expect(limitedNames[0]).toBe('Sugar');
 });
 
+test('likes endpoint returns saved names without duplicates', async () => {
+	const first = await callApi('/api/recipes', {
+		method: 'POST',
+		body: JSON.stringify({
+			cookbook_id: 1,
+			title: 'Liked Toast',
+			description: '',
+			author: '',
+			ingredients: [],
+			steps: [],
+			notes: ''
+		})
+	});
+	expect(first.status).toBe(200);
+	const firstRecipe = (await first.json()) as { id: number };
+
+	const second = await callApi('/api/recipes', {
+		method: 'POST',
+		body: JSON.stringify({
+			cookbook_id: 1,
+			title: 'Also Liked',
+			description: '',
+			author: '',
+			ingredients: [],
+			steps: [],
+			notes: ''
+		})
+	});
+	expect(second.status).toBe(200);
+	const secondRecipe = (await second.json()) as { id: number };
+
+	for (const [recipeId, name] of [
+		[firstRecipe.id, 'Alex'],
+		[firstRecipe.id, 'Sam'],
+		[secondRecipe.id, 'Alex']
+	] as const) {
+		const like = await callApi(`/api/recipes/${recipeId}/likes`, {
+			method: 'POST',
+			body: JSON.stringify({ name })
+		});
+		expect(like.status).toBe(200);
+	}
+
+	const cookbookRes = await callApi('/api/cookbooks', {
+		method: 'POST',
+		body: JSON.stringify({ name: `Likes ${Date.now()}` })
+	});
+	expect(cookbookRes.status).toBe(200);
+	const cookbook2 = (await cookbookRes.json()) as { id: number };
+
+	const otherRecipeRes = await callApi('/api/recipes', {
+		method: 'POST',
+		body: JSON.stringify({
+			cookbook_id: cookbook2.id,
+			title: 'Other Liked',
+			description: '',
+			author: '',
+			ingredients: [],
+			steps: [],
+			notes: ''
+		})
+	});
+	expect(otherRecipeRes.status).toBe(200);
+	const otherRecipe = (await otherRecipeRes.json()) as { id: number };
+	const otherLike = await callApi(`/api/recipes/${otherRecipe.id}/likes`, {
+		method: 'POST',
+		body: JSON.stringify({ name: 'Jordan' })
+	});
+	expect(otherLike.status).toBe(200);
+
+	const res = await callApi('/api/likes?cookbookId=1');
+	expect(res.status).toBe(200);
+	const names = (await res.json()) as string[];
+	expect(names).toEqual(['Alex', 'Sam']);
+	expect(names).not.toContain('Jordan');
+
+	const scoped = await callApi(`/api/likes?cookbookId=${cookbook2.id}`);
+	expect(scoped.status).toBe(200);
+	await expect(scoped.json()).resolves.toEqual(['Jordan']);
+
+	const limited = await callApi('/api/likes?cookbookId=1&q=a&limit=1');
+	expect(limited.status).toBe(200);
+	await expect(limited.json()).resolves.toEqual(['Alex']);
+});
+
 test('search finds recipes by ingredient name or line and records ingredient_id', async () => {
 	const createRes = await callApi('/api/recipes', {
 		method: 'POST',


### PR DESCRIPTION
## Summary
- Add a `/api/likes` suggestion endpoint scoped by cookbook and query term.
- Wire recipe cards to fetch and reuse saved like names for quick-like and add-like autocomplete.
- Update route protection and client API helpers so like mutations and suggestions share the same auth path.
- Expand tests for server-side deduplication, cookbook scoping, and UI autocomplete behavior.

## Testing
- Added server coverage for `/api/likes` with duplicate removal, cookbook scoping, and limit/query handling.
- Added component coverage for selecting a saved like name from autocomplete.
- Not run (not requested)