### PR TITLE
Add cooking water rules to recipes and calculator UI

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -28,6 +28,11 @@ interface RecipeRecord {
 	author: string;
 	uses: number;
 	servings: number;
+	cooking_water_amount_grams_per_serving: number | null;
+	cooking_water_minimum_water_liters: number | null;
+	cooking_water_extra_water_liters: number | null;
+	cooking_water_extra_water_per_grams: number | null;
+	cooking_water_salt_grams_per_liter: number | null;
 	created_at: string;
 }
 
@@ -45,6 +50,16 @@ interface StepRow {
 }
 
 const nonEmptyString = z.string().trim().min(1);
+const positiveFiniteNumber = z.number().finite().positive();
+const cookingWaterRuleSchema = z
+	.object({
+		amountGramsPerServing: positiveFiniteNumber,
+		minimumWaterLiters: positiveFiniteNumber,
+		extraWaterLiters: positiveFiniteNumber,
+		extraWaterPerGrams: positiveFiniteNumber,
+		saltGramsPerLiter: positiveFiniteNumber
+	})
+	.strict();
 const DEFAULT_PHOTO_THUMBNAIL_MAX_DATA_URL_LENGTH = 2_000_000;
 const parsePositiveIntegerEnv = (name: string, defaultValue: number) => {
 	const raw = process.env[name]?.trim();
@@ -69,6 +84,7 @@ const recipeBaseSchema = z
 		notes: z.string().max(10_000).optional(),
 		photoDataUrl: z.union([z.string().max(35_000_000), z.null()]).optional(),
 		photoThumbnailDataUrl: z.union([z.string().max(PHOTO_THUMBNAIL_MAX_DATA_URL_LENGTH), z.null()]).optional(),
+		cookingWaterRule: z.union([cookingWaterRuleSchema, z.null()]).optional(),
 		tags: z.array(z.string().trim().min(1).max(64)).max(50).optional()
 	})
 	.strict();
@@ -207,6 +223,11 @@ CREATE TABLE IF NOT EXISTS recipes (
 	author TEXT DEFAULT '',
 	uses INTEGER DEFAULT 0,
 	servings INTEGER DEFAULT 1,
+	cooking_water_amount_grams_per_serving REAL,
+	cooking_water_minimum_water_liters REAL,
+	cooking_water_extra_water_liters REAL,
+	cooking_water_extra_water_per_grams REAL,
+	cooking_water_salt_grams_per_liter REAL,
 	created_at TEXT DEFAULT CURRENT_TIMESTAMP,
 	FOREIGN KEY(cookbook_id) REFERENCES cookbooks(id) ON DELETE CASCADE
 );
@@ -359,7 +380,12 @@ migrateRecipePhotoVariantsToBlobStorage();
 
 const columnDefinitions = {
 	recipes: {
-		servings: 'INTEGER DEFAULT 1'
+		servings: 'INTEGER DEFAULT 1',
+		cooking_water_amount_grams_per_serving: 'REAL',
+		cooking_water_minimum_water_liters: 'REAL',
+		cooking_water_extra_water_liters: 'REAL',
+		cooking_water_extra_water_per_grams: 'REAL',
+		cooking_water_salt_grams_per_liter: 'REAL'
 	},
 	ingredients: {
 		ingredient_id: 'INTEGER',
@@ -387,6 +413,11 @@ function ensureColumn<T extends keyof ColumnDefinitions>(table: T, column: keyof
 }
 
 ensureColumn('recipes', 'servings');
+ensureColumn('recipes', 'cooking_water_amount_grams_per_serving');
+ensureColumn('recipes', 'cooking_water_minimum_water_liters');
+ensureColumn('recipes', 'cooking_water_extra_water_liters');
+ensureColumn('recipes', 'cooking_water_extra_water_per_grams');
+ensureColumn('recipes', 'cooking_water_salt_grams_per_liter');
 ensureColumn('ingredients', 'ingredient_id');
 ensureColumn('ingredients', 'quantity');
 ensureColumn('ingredients', 'unit');
@@ -867,6 +898,29 @@ const fetchPhotoUrls = (ids: number[]) => {
 	return grouped;
 };
 
+const serializeRecipeRecord = (recipe: RecipeRecord) => {
+	const {
+		cooking_water_amount_grams_per_serving: amountGramsPerServing,
+		cooking_water_minimum_water_liters: minimumWaterLiters,
+		cooking_water_extra_water_liters: extraWaterLiters,
+		cooking_water_extra_water_per_grams: extraWaterPerGrams,
+		cooking_water_salt_grams_per_liter: saltGramsPerLiter,
+		...rest
+	} = recipe;
+	const cookingWaterRule =
+		amountGramsPerServing === null ||
+		minimumWaterLiters === null ||
+		extraWaterLiters === null ||
+		extraWaterPerGrams === null ||
+		saltGramsPerLiter === null
+			? null
+			: { amountGramsPerServing, minimumWaterLiters, extraWaterLiters, extraWaterPerGrams, saltGramsPerLiter };
+	return {
+		...rest,
+		cookingWaterRule
+	};
+};
+
 const withRecipeMetadata = (recipes: RecipeRecord[]) => {
 	if (!recipes.length) return [];
 	const ids = recipes.map((r) => r.id as number);
@@ -876,8 +930,9 @@ const withRecipeMetadata = (recipes: RecipeRecord[]) => {
 	const photosBy = fetchPhotoUrls(ids);
 	return recipes.map((r) => {
 		const photos = photosBy[r.id] ?? {};
+		const recipe = serializeRecipeRecord(r);
 		return {
-			...r,
+			...recipe,
 			photo: photos.thumbnail_card ?? null,
 			photoFull: photos.full ?? null,
 			photoDetail: photos.thumbnail_detail ?? null,
@@ -1074,7 +1129,10 @@ export const app = new Elysia({
 		if (!parsed.success) return validationError(set, parsed.error);
 		const { cookbookId } = parsed.data;
 		const recipes = allStatement<RecipeRecord>(
-			`SELECT id, cookbook_id, title, description, author, uses, servings, created_at
+			`SELECT id, cookbook_id, title, description, author, uses, servings,
+					cooking_water_amount_grams_per_serving, cooking_water_minimum_water_liters,
+					cooking_water_extra_water_liters, cooking_water_extra_water_per_grams,
+					cooking_water_salt_grams_per_liter, created_at
 			 FROM recipes WHERE cookbook_id = ?
 			 ORDER BY title COLLATE NOCASE ASC, id ASC`,
 			cookbookId
@@ -1115,7 +1173,10 @@ export const app = new Elysia({
 		}
 		const limitClause = hasTerm ? 'LIMIT 200' : '';
 		const recipes = allStatement<RecipeRecord>(
-			`SELECT r.id, r.cookbook_id, r.title, r.description, r.author, r.uses, r.servings, r.created_at
+			`SELECT r.id, r.cookbook_id, r.title, r.description, r.author, r.uses, r.servings,
+					r.cooking_water_amount_grams_per_serving, r.cooking_water_minimum_water_liters,
+					r.cooking_water_extra_water_liters, r.cooking_water_extra_water_per_grams,
+					r.cooking_water_salt_grams_per_liter, r.created_at
 			 FROM recipes r
 			 WHERE r.cookbook_id = ?
 			 ${whereClause}
@@ -1148,7 +1209,10 @@ export const app = new Elysia({
 		if (!parsed.success) return validationError(set, parsed.error);
 		const id = parsed.data.id;
 		const recipe = getStatement<RecipeRecord>(
-			`SELECT id, cookbook_id, title, description, author, uses, servings, created_at
+			`SELECT id, cookbook_id, title, description, author, uses, servings,
+					cooking_water_amount_grams_per_serving, cooking_water_minimum_water_liters,
+					cooking_water_extra_water_liters, cooking_water_extra_water_per_grams,
+					cooking_water_salt_grams_per_liter, created_at
 			 FROM recipes WHERE id=?`,
 			id
 		);
@@ -1183,7 +1247,7 @@ export const app = new Elysia({
 			.filter((v, idx, arr) => v && arr.indexOf(v) === idx);
 		const photos = fetchPhotoUrls([id])[id] ?? {};
 		return {
-			...recipe,
+			...serializeRecipeRecord(recipe),
 			photo: photos.full ?? photos.thumbnail_card ?? null,
 			photoFull: photos.full ?? null,
 			photoDetail: photos.thumbnail_detail ?? null,
@@ -1209,14 +1273,25 @@ export const app = new Elysia({
 			return badRequest(set, 'photoThumbnailDataUrl requires supplied photoDataUrl');
 		}
 		const create = (payload: RecipeCreateInput) => {
+			const cookingWaterRule = payload.cookingWaterRule ?? null;
 			const info = runStatement(
-				`INSERT INTO recipes (cookbook_id, title, description, author, servings)
-				 VALUES (?,?,?,?,?)`,
+				`INSERT INTO recipes (
+					cookbook_id, title, description, author, servings,
+					cooking_water_amount_grams_per_serving, cooking_water_minimum_water_liters,
+					cooking_water_extra_water_liters, cooking_water_extra_water_per_grams,
+					cooking_water_salt_grams_per_liter
+				)
+				 VALUES (?,?,?,?,?,?,?,?,?,?)`,
 				payload.cookbook_id,
 				payload.title,
 				payload.description ?? '',
 				payload.author ?? '',
-				payload.servings ?? 1
+				payload.servings ?? 1,
+				cookingWaterRule?.amountGramsPerServing ?? null,
+				cookingWaterRule?.minimumWaterLiters ?? null,
+				cookingWaterRule?.extraWaterLiters ?? null,
+				cookingWaterRule?.extraWaterPerGrams ?? null,
+				cookingWaterRule?.saltGramsPerLiter ?? null
 			);
 			const recipeId = Number(info.lastInsertRowid);
 			if (payload.photoDataUrl) {
@@ -1244,6 +1319,7 @@ export const app = new Elysia({
 		if (!parsed.success) return validationError(set, parsed.error);
 		const hasPhotoDataUrl = Object.prototype.hasOwnProperty.call(parsed.data, 'photoDataUrl');
 		const hasPhotoThumbnailDataUrl = Object.prototype.hasOwnProperty.call(parsed.data, 'photoThumbnailDataUrl');
+		const hasCookingWaterRule = Object.prototype.hasOwnProperty.call(parsed.data, 'cookingWaterRule');
 		if (parsed.data.photoDataUrl != null && !isAllowedPhotoDataUrl(parsed.data.photoDataUrl)) {
 			return badRequest(set, 'photoDataUrl must be a supported image data URL');
 		}
@@ -1301,6 +1377,23 @@ export const app = new Elysia({
 			if (payload.servings !== undefined) {
 				updates.push('servings = ?');
 				params.push(payload.servings);
+			}
+			if (hasCookingWaterRule) {
+				const cookingWaterRule = payload.cookingWaterRule ?? null;
+				updates.push(
+					'cooking_water_amount_grams_per_serving = ?',
+					'cooking_water_minimum_water_liters = ?',
+					'cooking_water_extra_water_liters = ?',
+					'cooking_water_extra_water_per_grams = ?',
+					'cooking_water_salt_grams_per_liter = ?'
+				);
+				params.push(
+					cookingWaterRule?.amountGramsPerServing ?? null,
+					cookingWaterRule?.minimumWaterLiters ?? null,
+					cookingWaterRule?.extraWaterLiters ?? null,
+					cookingWaterRule?.extraWaterPerGrams ?? null,
+					cookingWaterRule?.saltGramsPerLiter ?? null
+				);
 			}
 			if (updates.length) {
 				params.push(id);

--- a/src/components/CookingWaterRuleFields.tsx
+++ b/src/components/CookingWaterRuleFields.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-import { ChevronDownIcon } from 'lucide-react';
+import { ChevronDownIcon, Info } from 'lucide-react';
 import { Input } from './ui/input';
 import { Switch } from './ui/switch';
-import type { CookingWaterRule, CookingWaterRuleDraft } from '../lib/cookingWater';
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+import type { CookingWaterRuleDraft } from '../lib/cookingWater';
 
 type CookingWaterRuleFieldsProps = {
 	idPrefix: string;
@@ -13,7 +14,7 @@ type CookingWaterRuleFieldsProps = {
 	onDraftChange: (draft: CookingWaterRuleDraft) => void;
 };
 
-type FieldKey = keyof CookingWaterRule;
+type FieldKey = keyof CookingWaterRuleDraft;
 
 function updateDraft(draft: CookingWaterRuleDraft, key: FieldKey, value: string) {
 	return { ...draft, [key]: value };
@@ -28,17 +29,17 @@ type NumberFieldProps = {
 
 function NumberField({ label, value, suffix, onChange }: NumberFieldProps) {
 	return (
-		<label className="space-y-1 text-xs text-muted-foreground">
-			<span>{label}</span>
+		<label className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 text-xs text-muted-foreground">
+			<span className="truncate">{label}</span>
 			<div className="flex items-center gap-2">
 				<Input
 					type="text"
 					inputMode="decimal"
 					value={value}
 					onChange={(event) => onChange(event.target.value)}
-					className="h-8"
+					className="h-8 w-20"
 				/>
-				<span className="w-8 text-foreground">{suffix}</span>
+				<span className="w-8 text-sm text-foreground">{suffix}</span>
 			</div>
 		</label>
 	);
@@ -67,9 +68,25 @@ export function CookingWaterRuleFields({
 	return (
 		<div className="rounded-md border border-border/70 bg-muted/30 p-3.5">
 			<div className="flex items-center justify-between gap-3">
-				<label htmlFor={`${idPrefix}-enabled`} className="text-sm font-medium">
-					Cooking water
-				</label>
+				<div className="flex items-center gap-1.5">
+					<label htmlFor={`${idPrefix}-enabled`} className="text-sm font-medium">
+						Cooking water
+					</label>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<button
+								type="button"
+								aria-label="Cooking water help"
+								className="flex h-5 w-5 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
+							>
+								<Info className="h-3.5 w-3.5" />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent side="top" sideOffset={6} className="max-w-64 text-left leading-5">
+							Minimum water is the starting amount. Extra water is added once for each selected serving. Salt is calculated from the final water amount.
+						</TooltipContent>
+					</Tooltip>
+				</div>
 				<div className="flex items-center gap-2">
 					<button
 						type="button"
@@ -86,57 +103,25 @@ export function CookingWaterRuleFields({
 				</div>
 			</div>
 			{showFields && (
-				<div className="mt-3 space-y-3">
-					<div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-						<NumberField
-							label="Minimum water"
-							value={draft.minimumWaterLiters}
-							suffix="L"
-							onChange={(value) => setField('minimumWaterLiters', value)}
-						/>
-						<NumberField
-							label="Salt"
-							value={draft.saltGramsPerLiter}
-							suffix="g/L"
-							onChange={(value) => setField('saltGramsPerLiter', value)}
-						/>
-					</div>
-					<div className="grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
-						<NumberField
-							label="Amount per serving"
-							value={draft.amountGramsPerServing}
-							suffix="g"
-							onChange={(value) => setField('amountGramsPerServing', value)}
-						/>
-						<div className="space-y-1">
-							<div className="text-xs text-muted-foreground">Extra water</div>
-							<div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2">
-								<div className="flex items-center gap-2">
-									<Input
-										aria-label="Extra water"
-										type="text"
-										inputMode="decimal"
-										value={draft.extraWaterLiters}
-										onChange={(event) => setField('extraWaterLiters', event.target.value)}
-										className="h-8"
-									/>
-									<span className="text-sm text-foreground">L</span>
-								</div>
-								<span className="text-xs text-muted-foreground">per</span>
-								<div className="flex items-center gap-2">
-									<Input
-										aria-label="Extra water per amount"
-										type="text"
-										inputMode="decimal"
-										value={draft.extraWaterPerGrams}
-										onChange={(event) => setField('extraWaterPerGrams', event.target.value)}
-										className="h-8"
-									/>
-									<span className="text-sm text-foreground">g</span>
-								</div>
-							</div>
-						</div>
-					</div>
+				<div className="mt-3 space-y-2.5">
+					<NumberField
+						label="Minimum water"
+						value={draft.minimumWaterLiters}
+						suffix="L"
+						onChange={(value) => setField('minimumWaterLiters', value)}
+					/>
+					<NumberField
+						label="Extra water per serving"
+						value={draft.extraWaterLitersPerServing}
+						suffix="L"
+						onChange={(value) => setField('extraWaterLitersPerServing', value)}
+					/>
+					<NumberField
+						label="Salt"
+						value={draft.saltGramsPerLiter}
+						suffix="g/L"
+						onChange={(value) => setField('saltGramsPerLiter', value)}
+					/>
 					{error && <div className="text-xs text-destructive">{error}</div>}
 				</div>
 			)}

--- a/src/components/CookingWaterRuleFields.tsx
+++ b/src/components/CookingWaterRuleFields.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react';
+import { ChevronDownIcon } from 'lucide-react';
+import { Input } from './ui/input';
+import { Switch } from './ui/switch';
+import type { CookingWaterRule, CookingWaterRuleDraft } from '../lib/cookingWater';
+
+type CookingWaterRuleFieldsProps = {
+	idPrefix: string;
+	enabled: boolean;
+	draft: CookingWaterRuleDraft;
+	error?: string;
+	onEnabledChange: (enabled: boolean) => void;
+	onDraftChange: (draft: CookingWaterRuleDraft) => void;
+};
+
+type FieldKey = keyof CookingWaterRule;
+
+function updateDraft(draft: CookingWaterRuleDraft, key: FieldKey, value: string) {
+	return { ...draft, [key]: value };
+}
+
+type NumberFieldProps = {
+	label: string;
+	value: string;
+	suffix: string;
+	onChange: (value: string) => void;
+};
+
+function NumberField({ label, value, suffix, onChange }: NumberFieldProps) {
+	return (
+		<label className="space-y-1 text-xs text-muted-foreground">
+			<span>{label}</span>
+			<div className="flex items-center gap-2">
+				<Input
+					type="text"
+					inputMode="decimal"
+					value={value}
+					onChange={(event) => onChange(event.target.value)}
+					className="h-8"
+				/>
+				<span className="w-8 text-foreground">{suffix}</span>
+			</div>
+		</label>
+	);
+}
+
+export function CookingWaterRuleFields({
+	idPrefix,
+	enabled,
+	draft,
+	error,
+	onEnabledChange,
+	onDraftChange
+}: CookingWaterRuleFieldsProps) {
+	const [expanded, setExpanded] = useState(true);
+	const setField = (key: FieldKey, value: string) => {
+		onDraftChange(updateDraft(draft, key, value));
+	};
+	const showFields = enabled && expanded;
+	const toggleLabel = expanded ? 'Collapse cooking water fields' : 'Expand cooking water fields';
+
+	const handleEnabledChange = (nextEnabled: boolean) => {
+		if (nextEnabled) setExpanded(true);
+		onEnabledChange(nextEnabled);
+	};
+
+	return (
+		<div className="rounded-md border border-border/70 bg-muted/30 p-3.5">
+			<div className="flex items-center justify-between gap-3">
+				<label htmlFor={`${idPrefix}-enabled`} className="text-sm font-medium">
+					Cooking water
+				</label>
+				<div className="flex items-center gap-2">
+					<button
+						type="button"
+						aria-label={toggleLabel}
+						aria-expanded={showFields}
+						title={toggleLabel}
+						disabled={!enabled}
+						onClick={() => setExpanded((current) => !current)}
+						className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+					>
+						<ChevronDownIcon className={`h-4 w-4 transition-transform ${expanded ? '' : '-rotate-90'}`} />
+					</button>
+					<Switch id={`${idPrefix}-enabled`} checked={enabled} onCheckedChange={handleEnabledChange} aria-label="Cooking water" />
+				</div>
+			</div>
+			{showFields && (
+				<div className="mt-3 space-y-3">
+					<div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+						<NumberField
+							label="Minimum water"
+							value={draft.minimumWaterLiters}
+							suffix="L"
+							onChange={(value) => setField('minimumWaterLiters', value)}
+						/>
+						<NumberField
+							label="Salt"
+							value={draft.saltGramsPerLiter}
+							suffix="g/L"
+							onChange={(value) => setField('saltGramsPerLiter', value)}
+						/>
+					</div>
+					<div className="grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
+						<NumberField
+							label="Amount per serving"
+							value={draft.amountGramsPerServing}
+							suffix="g"
+							onChange={(value) => setField('amountGramsPerServing', value)}
+						/>
+						<div className="space-y-1">
+							<div className="text-xs text-muted-foreground">Extra water</div>
+							<div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2">
+								<div className="flex items-center gap-2">
+									<Input
+										aria-label="Extra water"
+										type="text"
+										inputMode="decimal"
+										value={draft.extraWaterLiters}
+										onChange={(event) => setField('extraWaterLiters', event.target.value)}
+										className="h-8"
+									/>
+									<span className="text-sm text-foreground">L</span>
+								</div>
+								<span className="text-xs text-muted-foreground">per</span>
+								<div className="flex items-center gap-2">
+									<Input
+										aria-label="Extra water per amount"
+										type="text"
+										inputMode="decimal"
+										value={draft.extraWaterPerGrams}
+										onChange={(event) => setField('extraWaterPerGrams', event.target.value)}
+										className="h-8"
+									/>
+									<span className="text-sm text-foreground">g</span>
+								</div>
+							</div>
+						</div>
+					</div>
+					{error && <div className="text-xs text-destructive">{error}</div>}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -1116,7 +1116,6 @@ export function RecipeCard({
 											<span className="font-medium">Cooking water</span>
 											<span className="ml-2 text-muted-foreground">
 												For {viewServings} {viewServings === 1 ? 'serving' : 'servings'}:{' '}
-												{formatCookingWaterAmount(cookingWaterResult.amountGrams)} g batch,{' '}
 												{formatCookingWaterAmount(cookingWaterResult.waterLiters)} L water,{' '}
 												{formatCookingWaterAmount(cookingWaterResult.saltGrams)} g salt
 											</span>

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -10,6 +10,15 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
 import { Input } from './ui/input';
 import { Textarea } from './ui/textarea';
 import { TagSuggestions } from './TagSuggestions';
+import { CookingWaterRuleFields } from './CookingWaterRuleFields';
+import {
+	calculateCookingWater,
+	createCookingWaterRuleDraft,
+	formatCookingWaterAmount,
+	parseCookingWaterRuleDraft,
+	type CookingWaterRule,
+	type CookingWaterRuleDraft
+} from '../lib/cookingWater';
 
 type BaseIngredient = Omit<StructuredIngredient, 'line'> & { line?: string | null };
 
@@ -25,6 +34,7 @@ interface RecipeSummary {
 	hasPhoto?: boolean;
 	uses?: number;
 	servings?: number;
+	cookingWaterRule?: CookingWaterRule | null;
 	created_at?: string;
 	tags: string[];
 	likes: string[];
@@ -111,6 +121,7 @@ const normalizeRecipeDetail = (summary: RecipeSummary, data: Partial<RecipeDetai
 		photo: data.photo ?? summary.photo ?? null,
 		uses: data.uses ?? summary.uses ?? 0,
 		servings: data.servings ?? summary.servings ?? 1,
+		cookingWaterRule: data.cookingWaterRule !== undefined ? data.cookingWaterRule : summary.cookingWaterRule ?? null,
 		tags: data.tags ?? summary.tags ?? [],
 		likes: uniqNames(data.likes ?? summary.likes ?? []),
 		ingredients: normalizeIngredients(data.ingredients),
@@ -168,6 +179,9 @@ export function RecipeCard({
 	const genKey = () => (typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : Math.random().toString(36).slice(2));
 	const [eservings, setEServings] = useState<number>(1);
 	const [viewServings, setViewServings] = useState<number>(1);
+	const [ecookingWaterEnabled, setECookingWaterEnabled] = useState(false);
+	const [ecookingWaterDraft, setECookingWaterDraft] = useState<CookingWaterRuleDraft>(() => createCookingWaterRuleDraft());
+	const [ecookingWaterError, setECookingWaterError] = useState('');
 	const [enotes, setENotes] = useState('');
 	const [addingTag, setAddingTag] = useState(false);
 	const [tagValue, setTagValue] = useState('');
@@ -556,16 +570,26 @@ export function RecipeCard({
 		setENotes(full.notes || '');
 		setEServings(full.servings || 1);
 		setViewServings(full.servings || 1);
+		setECookingWaterEnabled(Boolean(full.cookingWaterRule));
+		setECookingWaterDraft(createCookingWaterRuleDraft(full.cookingWaterRule ?? undefined));
+		setECookingWaterError('');
 		setLikes(full.likes || likes);
 		setEditing(true);
 	};
 	const saveEdit = async () => {
 		if (!full) return;
+		const cookingWaterRule = ecookingWaterEnabled ? parseCookingWaterRuleDraft(ecookingWaterDraft) : null;
+		if (ecookingWaterEnabled && !cookingWaterRule) {
+			setECookingWaterError('Enter positive numbers for the cooking water rule.');
+			return;
+		}
+		setECookingWaterError('');
 		await updateRecipe(full.id, {
 			title: etitle.trim(),
 			author: eauthor.trim(),
 			description: edesc,
 			servings: eservings,
+			cookingWaterRule,
 			ingredients: eing.map(({ _k, ...rest }) => {
 				void _k;
 				return rest;
@@ -895,6 +919,8 @@ export function RecipeCard({
 		document.body.removeChild(meas);
 	}, [recipe.tags]);
 
+	const cookingWaterResult = full?.cookingWaterRule ? calculateCookingWater(full.cookingWaterRule, viewServings) : null;
+
 	return (
 		<>
 			<div onClick={openDialog} role="button" tabIndex={0} className="min-h-[23rem] text-left relative group rounded-lg border border-border bg-card shadow-sm flex flex-col overflow-hidden hover:shadow-md transition-shadow cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-ring">
@@ -1085,6 +1111,17 @@ export function RecipeCard({
 											return <li key={`${ing.line ?? ing.name ?? i}`}>{parts || fallback}</li>;
 										})}
 									</ul>
+									{cookingWaterResult && (
+										<div className="mt-3 rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-sm">
+											<span className="font-medium">Cooking water</span>
+											<span className="ml-2 text-muted-foreground">
+												For {viewServings} {viewServings === 1 ? 'serving' : 'servings'}:{' '}
+												{formatCookingWaterAmount(cookingWaterResult.amountGrams)} g batch,{' '}
+												{formatCookingWaterAmount(cookingWaterResult.waterLiters)} L water,{' '}
+												{formatCookingWaterAmount(cookingWaterResult.saltGrams)} g salt
+											</span>
+										</div>
+									)}
 								</div>
 								<div>
 									<h4 className="font-semibold mb-2">Steps</h4>
@@ -1269,6 +1306,22 @@ export function RecipeCard({
 													onContainerChange={setIngredientSuggestionsNode}
 												/>, document.body
 											)}
+										</div>
+										<div className="mt-4">
+											<CookingWaterRuleFields
+												idPrefix={`edit-cooking-water-${full?.id ?? recipe.id}`}
+												enabled={ecookingWaterEnabled}
+												draft={ecookingWaterDraft}
+												error={ecookingWaterError}
+												onEnabledChange={(enabled) => {
+													setECookingWaterEnabled(enabled);
+													setECookingWaterError('');
+												}}
+												onDraftChange={(draft) => {
+													setECookingWaterDraft(draft);
+													setECookingWaterError('');
+												}}
+											/>
 										</div>
 									</div>
 									<div>

--- a/src/components/RecipeCreateCard.tsx
+++ b/src/components/RecipeCreateCard.tsx
@@ -11,6 +11,8 @@ import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '.
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
 import { GripVertical, X as XIcon, ImagePlus } from 'lucide-react';
 import { TagSuggestions } from './TagSuggestions';
+import { CookingWaterRuleFields } from './CookingWaterRuleFields';
+import { createCookingWaterRuleDraft, parseCookingWaterRuleDraft, type CookingWaterRuleDraft } from '../lib/cookingWater';
 
 type EditableIngredient = StructuredIngredient & { _k: string };
 type EditableStep = { _k: string; text: string };
@@ -39,6 +41,9 @@ export function RecipeCreateCard({ cookbookId, onCreated }: Props) {
 	const [author, setAuthor] = useState('');
 	const [description, setDescription] = useState('');
 	const [servings, setServings] = useState<number>(1);
+	const [cookingWaterEnabled, setCookingWaterEnabled] = useState(false);
+	const [cookingWaterDraft, setCookingWaterDraft] = useState<CookingWaterRuleDraft>(() => createCookingWaterRuleDraft());
+	const [cookingWaterError, setCookingWaterError] = useState('');
 	const [ingredients, setIngredients] = useState<EditableIngredient[]>([createBlankIngredient()]);
 	const [filteredIngredients, setFilteredIngredients] = useState<string[]>([]);
 	const [activeIngredientIndex, setActiveIngredientIndex] = useState<number | null>(null);
@@ -186,6 +191,9 @@ export function RecipeCreateCard({ cookbookId, onCreated }: Props) {
 		setAuthor('');
 		setDescription('');
 		setServings(1);
+		setCookingWaterEnabled(false);
+		setCookingWaterDraft(createCookingWaterRuleDraft());
+		setCookingWaterError('');
 		setIngredients([createBlankIngredient()]);
 		setSteps([createBlankStep()]);
 		setNotes('');
@@ -199,6 +207,12 @@ export function RecipeCreateCard({ cookbookId, onCreated }: Props) {
 	}, [allTags]);
 	const submit = async () => {
 	if (!title.trim()) return;
+	const cookingWaterRule = cookingWaterEnabled ? parseCookingWaterRuleDraft(cookingWaterDraft) : null;
+	if (cookingWaterEnabled && !cookingWaterRule) {
+		setCookingWaterError('Enter positive numbers for the cooking water rule.');
+		return;
+	}
+	setCookingWaterError('');
 	const cleanedIngredients = ingredients
 		.filter(i=> (i.name||'').trim() || (i.line||'').trim())
 		.map(({ _k, ...rest }) => {
@@ -217,6 +231,7 @@ export function RecipeCreateCard({ cookbookId, onCreated }: Props) {
 		notes: notes.trim(),
 		photoDataUrl: photo,
 		photoThumbnailDataUrl: photoThumbnail,
+		cookingWaterRule,
 		tags: tagList
 	});
 	resetForm();
@@ -509,6 +524,22 @@ export function RecipeCreateCard({ cookbookId, onCreated }: Props) {
 												onContainerChange={setIngredientSuggestionsNode}
 											/>, document.body
 										)}
+									</div>
+									<div className="mt-4">
+										<CookingWaterRuleFields
+											idPrefix="create-cooking-water"
+											enabled={cookingWaterEnabled}
+											draft={cookingWaterDraft}
+											error={cookingWaterError}
+											onEnabledChange={(enabled) => {
+												setCookingWaterEnabled(enabled);
+												setCookingWaterError('');
+											}}
+											onDraftChange={(draft) => {
+												setCookingWaterDraft(draft);
+												setCookingWaterError('');
+											}}
+										/>
 									</div>
 								</div>
 								<div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,5 @@
+import type { CookingWaterRule } from './cookingWater';
+
 export interface StructuredIngredient {
 	line?: string | null;
 	quantity?: number | null;
@@ -17,6 +19,7 @@ export type RecipeInput = {
 	notes?: string;
 	photoDataUrl?: string | null;
 	photoThumbnailDataUrl?: string | null;
+	cookingWaterRule?: CookingWaterRule | null;
 	tags?: string[];
 };
 
@@ -34,6 +37,7 @@ export type RecipeSummary = {
 	hasPhoto?: boolean;
 	uses: number;
 	servings: number;
+	cookingWaterRule: CookingWaterRule | null;
 	created_at: string;
 	tags: string[];
 	likes: string[];

--- a/src/lib/cookingWater.ts
+++ b/src/lib/cookingWater.ts
@@ -12,35 +12,44 @@ export type CookingWaterResult = {
 	saltGrams: number;
 };
 
-export type CookingWaterRuleDraft = Record<keyof CookingWaterRule, string>;
+export type CookingWaterRuleDraft = {
+	minimumWaterLiters: string;
+	extraWaterLitersPerServing: string;
+	saltGramsPerLiter: string;
+};
+
+const STORAGE_AMOUNT_GRAMS_PER_SERVING = 100;
 
 export const DEFAULT_COOKING_WATER_RULE: CookingWaterRule = {
-	amountGramsPerServing: 100,
+	amountGramsPerServing: STORAGE_AMOUNT_GRAMS_PER_SERVING,
 	minimumWaterLiters: 1,
 	extraWaterLiters: 0.5,
-	extraWaterPerGrams: 100,
+	extraWaterPerGrams: STORAGE_AMOUNT_GRAMS_PER_SERVING,
 	saltGramsPerLiter: 11
 };
 
 export function createCookingWaterRuleDraft(rule: CookingWaterRule = DEFAULT_COOKING_WATER_RULE): CookingWaterRuleDraft {
+	const extraWaterLitersPerServing = rule.extraWaterLiters * (rule.amountGramsPerServing / rule.extraWaterPerGrams);
 	return {
-		amountGramsPerServing: String(rule.amountGramsPerServing),
 		minimumWaterLiters: String(rule.minimumWaterLiters),
-		extraWaterLiters: String(rule.extraWaterLiters),
-		extraWaterPerGrams: String(rule.extraWaterPerGrams),
+		extraWaterLitersPerServing: String(extraWaterLitersPerServing),
 		saltGramsPerLiter: String(rule.saltGramsPerLiter)
 	};
 }
 
 export function parseCookingWaterRuleDraft(draft: CookingWaterRuleDraft): CookingWaterRule | null {
-	const amountGramsPerServing = Number(draft.amountGramsPerServing.replace(/,/g, '.'));
 	const minimumWaterLiters = Number(draft.minimumWaterLiters.replace(/,/g, '.'));
-	const extraWaterLiters = Number(draft.extraWaterLiters.replace(/,/g, '.'));
-	const extraWaterPerGrams = Number(draft.extraWaterPerGrams.replace(/,/g, '.'));
+	const extraWaterLitersPerServing = Number(draft.extraWaterLitersPerServing.replace(/,/g, '.'));
 	const saltGramsPerLiter = Number(draft.saltGramsPerLiter.replace(/,/g, '.'));
-	const values = [amountGramsPerServing, minimumWaterLiters, extraWaterLiters, extraWaterPerGrams, saltGramsPerLiter];
+	const values = [minimumWaterLiters, extraWaterLitersPerServing, saltGramsPerLiter];
 	if (!values.every((value) => Number.isFinite(value) && value > 0)) return null;
-	return { amountGramsPerServing, minimumWaterLiters, extraWaterLiters, extraWaterPerGrams, saltGramsPerLiter };
+	return {
+		amountGramsPerServing: STORAGE_AMOUNT_GRAMS_PER_SERVING,
+		minimumWaterLiters,
+		extraWaterLiters: extraWaterLitersPerServing,
+		extraWaterPerGrams: STORAGE_AMOUNT_GRAMS_PER_SERVING,
+		saltGramsPerLiter
+	};
 }
 
 export function calculateCookingWater(rule: CookingWaterRule, servings: number): CookingWaterResult {

--- a/src/lib/cookingWater.ts
+++ b/src/lib/cookingWater.ts
@@ -1,0 +1,57 @@
+export type CookingWaterRule = {
+	amountGramsPerServing: number;
+	minimumWaterLiters: number;
+	extraWaterLiters: number;
+	extraWaterPerGrams: number;
+	saltGramsPerLiter: number;
+};
+
+export type CookingWaterResult = {
+	amountGrams: number;
+	waterLiters: number;
+	saltGrams: number;
+};
+
+export type CookingWaterRuleDraft = Record<keyof CookingWaterRule, string>;
+
+export const DEFAULT_COOKING_WATER_RULE: CookingWaterRule = {
+	amountGramsPerServing: 100,
+	minimumWaterLiters: 1,
+	extraWaterLiters: 0.5,
+	extraWaterPerGrams: 100,
+	saltGramsPerLiter: 11
+};
+
+export function createCookingWaterRuleDraft(rule: CookingWaterRule = DEFAULT_COOKING_WATER_RULE): CookingWaterRuleDraft {
+	return {
+		amountGramsPerServing: String(rule.amountGramsPerServing),
+		minimumWaterLiters: String(rule.minimumWaterLiters),
+		extraWaterLiters: String(rule.extraWaterLiters),
+		extraWaterPerGrams: String(rule.extraWaterPerGrams),
+		saltGramsPerLiter: String(rule.saltGramsPerLiter)
+	};
+}
+
+export function parseCookingWaterRuleDraft(draft: CookingWaterRuleDraft): CookingWaterRule | null {
+	const amountGramsPerServing = Number(draft.amountGramsPerServing.replace(/,/g, '.'));
+	const minimumWaterLiters = Number(draft.minimumWaterLiters.replace(/,/g, '.'));
+	const extraWaterLiters = Number(draft.extraWaterLiters.replace(/,/g, '.'));
+	const extraWaterPerGrams = Number(draft.extraWaterPerGrams.replace(/,/g, '.'));
+	const saltGramsPerLiter = Number(draft.saltGramsPerLiter.replace(/,/g, '.'));
+	const values = [amountGramsPerServing, minimumWaterLiters, extraWaterLiters, extraWaterPerGrams, saltGramsPerLiter];
+	if (!values.every((value) => Number.isFinite(value) && value > 0)) return null;
+	return { amountGramsPerServing, minimumWaterLiters, extraWaterLiters, extraWaterPerGrams, saltGramsPerLiter };
+}
+
+export function calculateCookingWater(rule: CookingWaterRule, servings: number): CookingWaterResult {
+	const safeServings = Number.isFinite(servings) && servings > 0 ? servings : 1;
+	const amountGrams = rule.amountGramsPerServing * safeServings;
+	const waterLiters = rule.minimumWaterLiters + rule.extraWaterLiters * (amountGrams / rule.extraWaterPerGrams);
+	const saltGrams = waterLiters * rule.saltGramsPerLiter;
+	return { amountGrams, waterLiters, saltGrams };
+}
+
+export function formatCookingWaterAmount(value: number) {
+	const rounded = Math.round(value * 10) / 10;
+	return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}

--- a/tests/components/RecipeCard.test.tsx
+++ b/tests/components/RecipeCard.test.tsx
@@ -211,14 +211,14 @@ describe('RecipeCard', () => {
 			fireEvent.click(getByText('Toast'));
 
 			await waitFor(() => {
-				expect(getByText('For 1 serving: 100 g batch, 1.5 L water, 16.5 g salt')).toBeTruthy();
+				expect(getByText('For 1 serving: 1.5 L water, 16.5 g salt')).toBeTruthy();
 			});
 
 			fireEvent.click(getByRole('combobox'));
 			fireEvent.click(getByText('5'));
 
 			await waitFor(() => {
-				expect(getByText('For 5 servings: 500 g batch, 3.5 L water, 38.5 g salt')).toBeTruthy();
+				expect(getByText('For 5 servings: 3.5 L water, 38.5 g salt')).toBeTruthy();
 			});
 		} finally {
 			globalThis.fetch = originalFetch;
@@ -257,7 +257,7 @@ describe('RecipeCard', () => {
 			fireEvent.click(getByText('Toast'));
 
 			await waitFor(() => {
-				expect(getByText('For 1 serving: 100 g batch, 1.5 L water, 16.5 g salt')).toBeTruthy();
+				expect(getByText('For 1 serving: 1.5 L water, 16.5 g salt')).toBeTruthy();
 			});
 
 			fireEvent.click(getByRole('button', { name: 'Edit' }));
@@ -265,7 +265,7 @@ describe('RecipeCard', () => {
 			fireEvent.click(getByRole('button', { name: 'Save' }));
 
 			await waitFor(() => {
-				expect(queryByText('For 1 serving: 100 g batch, 1.5 L water, 16.5 g salt')).toBeNull();
+				expect(queryByText('For 1 serving: 1.5 L water, 16.5 g salt')).toBeNull();
 			});
 			expect(patchBodies[0]).toMatchObject({ cookingWaterRule: null });
 		} finally {
@@ -302,7 +302,7 @@ describe('RecipeCard', () => {
 
 			fireEvent.click(getByText('Toast'));
 			await waitFor(() => {
-				expect(getByText('For 1 serving: 100 g batch, 1.5 L water, 16.5 g salt')).toBeTruthy();
+				expect(getByText('For 1 serving: 1.5 L water, 16.5 g salt')).toBeTruthy();
 			});
 
 			fireEvent.click(getByRole('button', { name: 'Edit' }));

--- a/tests/components/RecipeCard.test.tsx
+++ b/tests/components/RecipeCard.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { RecipeCard } from '@/components/RecipeCard';
+import { DEFAULT_COOKING_WATER_RULE } from '@/lib/cookingWater';
 
 afterEach(() => {
 	cleanup();
@@ -180,6 +181,142 @@ describe('RecipeCard', () => {
 
 			await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/recipes/1', undefined));
 			expect(onAutoOpenHandled).toHaveBeenCalledTimes(1);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test('updates cooking water readout from selected servings', async () => {
+		const fetchMock = mock((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+			if (url.endsWith('/api/recipes/1')) {
+				return Promise.resolve(json({
+					...baseRecipe,
+					servings: 1,
+					cookingWaterRule: DEFAULT_COOKING_WATER_RULE,
+					ingredients: [{ quantity: 100, unit: 'g', name: 'pasta', line: '100 g pasta' }],
+					steps: ['Boil pasta'],
+					notes: '',
+					ingredientNames: ['pasta'],
+				}));
+			}
+			return Promise.resolve(json({ ok: true }));
+		});
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		try {
+			const { getByText, getByRole } = render(<RecipeCard recipe={{ ...baseRecipe }} onChange={() => {}} />);
+
+			fireEvent.click(getByText('Toast'));
+
+			await waitFor(() => {
+				expect(getByText('For 1 serving: 100 g batch, 1.5 L water, 16.5 g salt')).toBeTruthy();
+			});
+
+			fireEvent.click(getByRole('combobox'));
+			fireEvent.click(getByText('5'));
+
+			await waitFor(() => {
+				expect(getByText('For 5 servings: 500 g batch, 3.5 L water, 38.5 g salt')).toBeTruthy();
+			});
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test('clears cooking water readout when edit disables the rule', async () => {
+		let detailIncludesRule = true;
+		const patchBodies: unknown[] = [];
+		const fetchMock = mock((input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+			if (url.endsWith('/api/recipes/1') && init?.method === 'PATCH') {
+				patchBodies.push(JSON.parse(String(init.body)));
+				detailIncludesRule = false;
+				return Promise.resolve(json({ ok: true }));
+			}
+			if (url.endsWith('/api/recipes/1')) {
+				return Promise.resolve(json({
+					...baseRecipe,
+					servings: 1,
+					cookingWaterRule: detailIncludesRule ? DEFAULT_COOKING_WATER_RULE : null,
+					ingredients: [{ quantity: 100, unit: 'g', name: 'pasta', line: '100 g pasta' }],
+					steps: ['Boil pasta'],
+					notes: '',
+					ingredientNames: ['pasta'],
+				}));
+			}
+			return Promise.resolve(json({ ok: true }));
+		});
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		try {
+			const { getByText, getByRole, queryByText } = render(<RecipeCard recipe={{ ...baseRecipe }} onChange={() => {}} />);
+
+			fireEvent.click(getByText('Toast'));
+
+			await waitFor(() => {
+				expect(getByText('For 1 serving: 100 g batch, 1.5 L water, 16.5 g salt')).toBeTruthy();
+			});
+
+			fireEvent.click(getByRole('button', { name: 'Edit' }));
+			fireEvent.click(getByRole('switch', { name: 'Cooking water' }));
+			fireEvent.click(getByRole('button', { name: 'Save' }));
+
+			await waitFor(() => {
+				expect(queryByText('For 1 serving: 100 g batch, 1.5 L water, 16.5 g salt')).toBeNull();
+			});
+			expect(patchBodies[0]).toMatchObject({ cookingWaterRule: null });
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test('collapses cooking water fields without disabling the rule', async () => {
+		const patchBodies: unknown[] = [];
+		const fetchMock = mock((input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+			if (url.endsWith('/api/recipes/1') && init?.method === 'PATCH') {
+				patchBodies.push(JSON.parse(String(init.body)));
+				return Promise.resolve(json({ ok: true }));
+			}
+			if (url.endsWith('/api/recipes/1')) {
+				return Promise.resolve(json({
+					...baseRecipe,
+					servings: 1,
+					cookingWaterRule: DEFAULT_COOKING_WATER_RULE,
+					ingredients: [{ quantity: 100, unit: 'g', name: 'pasta', line: '100 g pasta' }],
+					steps: ['Boil pasta'],
+					notes: '',
+					ingredientNames: ['pasta'],
+				}));
+			}
+			return Promise.resolve(json({ ok: true }));
+		});
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		try {
+			const { getByText, getByRole, queryByDisplayValue } = render(<RecipeCard recipe={{ ...baseRecipe }} onChange={() => {}} />);
+
+			fireEvent.click(getByText('Toast'));
+			await waitFor(() => {
+				expect(getByText('For 1 serving: 100 g batch, 1.5 L water, 16.5 g salt')).toBeTruthy();
+			});
+
+			fireEvent.click(getByRole('button', { name: 'Edit' }));
+			const cookingWaterSwitch = getByRole('switch', { name: 'Cooking water' });
+			expect(cookingWaterSwitch.getAttribute('aria-checked')).toBe('true');
+			fireEvent.click(getByRole('button', { name: 'Collapse cooking water fields' }));
+
+			expect(cookingWaterSwitch.getAttribute('aria-checked')).toBe('true');
+			expect(queryByDisplayValue('11')).toBeNull();
+
+			fireEvent.click(getByRole('button', { name: 'Save' }));
+
+			await waitFor(() => expect(patchBodies).toHaveLength(1));
+			expect(patchBodies[0]).toMatchObject({ cookingWaterRule: DEFAULT_COOKING_WATER_RULE });
 		} finally {
 			globalThis.fetch = originalFetch;
 		}

--- a/tests/lib/cookingWater.test.ts
+++ b/tests/lib/cookingWater.test.ts
@@ -28,8 +28,8 @@ describe('cooking water helpers', () => {
 
 	test('parses draft values and rejects non-positive values', () => {
 		expect(parseCookingWaterRuleDraft(createCookingWaterRuleDraft())).toEqual(DEFAULT_COOKING_WATER_RULE);
-		expect(parseCookingWaterRuleDraft({ ...createCookingWaterRuleDraft(), extraWaterPerGrams: '0' })).toBeNull();
-		expect(parseCookingWaterRuleDraft({ ...createCookingWaterRuleDraft(), extraWaterLiters: '0,75' })).toMatchObject({
+		expect(parseCookingWaterRuleDraft({ ...createCookingWaterRuleDraft(), extraWaterLitersPerServing: '0' })).toBeNull();
+		expect(parseCookingWaterRuleDraft({ ...createCookingWaterRuleDraft(), extraWaterLitersPerServing: '0,75' })).toMatchObject({
 			extraWaterLiters: 0.75
 		});
 	});

--- a/tests/lib/cookingWater.test.ts
+++ b/tests/lib/cookingWater.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	DEFAULT_COOKING_WATER_RULE,
+	calculateCookingWater,
+	createCookingWaterRuleDraft,
+	formatCookingWaterAmount,
+	parseCookingWaterRuleDraft
+} from '@/lib/cookingWater';
+
+describe('cooking water helpers', () => {
+	test('calculates default water and salt from selected servings', () => {
+		expect(calculateCookingWater(DEFAULT_COOKING_WATER_RULE, 1)).toEqual({
+			amountGrams: 100,
+			waterLiters: 1.5,
+			saltGrams: 16.5
+		});
+		expect(calculateCookingWater(DEFAULT_COOKING_WATER_RULE, 2)).toEqual({
+			amountGrams: 200,
+			waterLiters: 2,
+			saltGrams: 22
+		});
+		expect(calculateCookingWater(DEFAULT_COOKING_WATER_RULE, 5)).toEqual({
+			amountGrams: 500,
+			waterLiters: 3.5,
+			saltGrams: 38.5
+		});
+	});
+
+	test('parses draft values and rejects non-positive values', () => {
+		expect(parseCookingWaterRuleDraft(createCookingWaterRuleDraft())).toEqual(DEFAULT_COOKING_WATER_RULE);
+		expect(parseCookingWaterRuleDraft({ ...createCookingWaterRuleDraft(), extraWaterPerGrams: '0' })).toBeNull();
+		expect(parseCookingWaterRuleDraft({ ...createCookingWaterRuleDraft(), extraWaterLiters: '0,75' })).toMatchObject({
+			extraWaterLiters: 0.75
+		});
+	});
+
+	test('formats values with at most one decimal', () => {
+		expect(formatCookingWaterAmount(2)).toBe('2');
+		expect(formatCookingWaterAmount(2.25)).toBe('2.3');
+		expect(formatCookingWaterAmount(38.5)).toBe('38.5');
+	});
+});

--- a/tests/server/index.test.ts
+++ b/tests/server/index.test.ts
@@ -156,6 +156,97 @@ test('recipe tags are returned alphabetically from recipe endpoints', async () =
 	expect(detailPayload.tags).toEqual(expectedTags);
 });
 
+test('recipe cooking water rule persists across recipe endpoints and validates positive values', async () => {
+	const omittedRes = await callApi('/api/recipes', {
+		method: 'POST',
+		body: JSON.stringify({
+			cookbook_id: 1,
+			title: 'No Cooking Water Rule',
+			description: '',
+			author: '',
+			ingredients: [],
+			steps: [],
+			notes: ''
+		})
+	});
+	expect(omittedRes.status).toBe(200);
+	const omittedRecipe = (await omittedRes.json()) as { id: number };
+	const omittedDetail = await callApi(`/api/recipes/${omittedRecipe.id}`);
+	expect(omittedDetail.status).toBe(200);
+	await expect(omittedDetail.json()).resolves.toMatchObject({ cookingWaterRule: null });
+
+	const rule = {
+		amountGramsPerServing: 100,
+		minimumWaterLiters: 1,
+		extraWaterLiters: 0.5,
+		extraWaterPerGrams: 100,
+		saltGramsPerLiter: 11
+	};
+	const createRes = await callApi('/api/recipes', {
+		method: 'POST',
+		body: JSON.stringify({
+			cookbook_id: 1,
+			title: 'Cooking Water Rule Recipe',
+			description: '',
+			author: '',
+			servings: 5,
+			ingredients: [],
+			steps: [],
+			notes: '',
+			cookingWaterRule: rule
+		})
+	});
+	expect(createRes.status).toBe(200);
+	const created = (await createRes.json()) as { id: number };
+
+	const detailRes = await callApi(`/api/recipes/${created.id}`);
+	expect(detailRes.status).toBe(200);
+	await expect(detailRes.json()).resolves.toMatchObject({ cookingWaterRule: rule });
+
+	const listRes = await callApi('/api/recipes?cookbookId=1');
+	expect(listRes.status).toBe(200);
+	const listPayload = (await listRes.json()) as Array<{ id: number; cookingWaterRule: unknown }>;
+	expect(listPayload.find((recipe) => recipe.id === created.id)?.cookingWaterRule).toEqual(rule);
+
+	const searchRes = await callApi('/api/recipes/search?cookbookId=1&q=Cooking%20Water%20Rule');
+	expect(searchRes.status).toBe(200);
+	const searchPayload = (await searchRes.json()) as Array<{ id: number; cookingWaterRule: unknown }>;
+	expect(searchPayload.find((recipe) => recipe.id === created.id)?.cookingWaterRule).toEqual(rule);
+
+	const updatedRule = { ...rule, minimumWaterLiters: 1.5, extraWaterLiters: 0.4 };
+	const patchRes = await callApi(`/api/recipes/${created.id}`, {
+		method: 'PATCH',
+		body: JSON.stringify({ cookingWaterRule: updatedRule })
+	});
+	expect(patchRes.status).toBe(200);
+	const updatedDetail = await callApi(`/api/recipes/${created.id}`);
+	await expect(updatedDetail.json()).resolves.toMatchObject({ cookingWaterRule: updatedRule });
+
+	const clearRes = await callApi(`/api/recipes/${created.id}`, {
+		method: 'PATCH',
+		body: JSON.stringify({ cookingWaterRule: null })
+	});
+	expect(clearRes.status).toBe(200);
+	const clearedDetail = await callApi(`/api/recipes/${created.id}`);
+	await expect(clearedDetail.json()).resolves.toMatchObject({ cookingWaterRule: null });
+
+	const invalidZero = await callApi('/api/recipes', {
+		method: 'POST',
+		body: JSON.stringify({
+			cookbook_id: 1,
+			title: 'Invalid Cooking Water Rule',
+			cookingWaterRule: { ...rule, extraWaterPerGrams: 0 }
+		})
+	});
+	expect(invalidZero.status).toBe(400);
+
+	const invalidPartial = await callApi(`/api/recipes/${created.id}`, {
+		method: 'PATCH',
+		body: JSON.stringify({ cookingWaterRule: { amountGramsPerServing: 100 } })
+	});
+	expect(invalidPartial.status).toBe(400);
+});
+
 test('recipe photo endpoints reject unsafe MIME types and do not echo legacy unsafe types', async () => {
 	const parameterizedCreate = await callApi('/api/recipes', {
 		method: 'POST',


### PR DESCRIPTION
## Summary
- Add nullable cooking water rule fields to recipe storage, serialization, create, and update flows.
- Introduce reusable client-side helpers for parsing, storing, and calculating water and salt amounts.
- Add create/edit UI for enabling a cooking water rule and show the computed readout on recipe cards.
- Cover the new behavior with tests for readout updates and rule removal during edit.

## Testing
- Added component tests for cooking water calculation, editing, and disabled-state behavior.
- Not run (not requested)